### PR TITLE
Alert 모달 스타일 수정 및 공유 기능 에러핸들링 보완

### DIFF
--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -214,6 +214,7 @@
   "alertNoImg": "No file chosen",
   "alertSuccessCopy": "Copied Successfully! ✨",
   "alertFailCopy": "Failed to copy...🥲",
-  "alertMacOS": "Chrome browser on Mac is not working. Open in another browser 🥰",
-  "alertKakao": "It is not working on kakaoTalk InAppBrowser.. Open in another browser 🥰"
+  "alertMacOS": "Chrome browser on Mac is not working. Open in another browser. 🥰",
+  "alertKakao": "It is not working on kakaoTalk InAppBrowser. Open in another browser. 🥰",
+  "alertNotSupportedBrowser": "It is not working on this browser. Open in another browser. 🥰"
 }

--- a/public/translations/ko.json
+++ b/public/translations/ko.json
@@ -22,8 +22,8 @@
   "explanation_3": "피부색이 균일하고 맑아 보이는 색이 잘 어울리는 색입니다.",
   "colorChoiceGuideTitle": "잘 어울리는 색 고르는 🍯TIP",
   "colorChoiceGuideExplanation_1": "색이 눈에 들어오는 게 아니라 ‘내’가 돋보여야 합니다!",
-  "colorChoiceGuideExplanation_2": "안 어울리는 색은? 🙁\n❌ 너무 더워보여요\n❌ 얼굴과 색이 분리되어 보여요",
-  "colorChoiceGuideExplanation_3": "잘 어울리는 색은? 😊\n⭕️ 얼굴 윤곽이 살아나요\n⭕️ 콧대랑 턱라인이 날렵해보여요",
+  "colorChoiceGuideExplanation_2": "안 어울리는 색은? 🙁\n❌ 너무 더워 보여요\n❌ 얼굴과 색이 분리되어 보여요",
+  "colorChoiceGuideExplanation_3": "잘 어울리는 색은? 😊\n⭕️ 얼굴 윤곽이 살아나요\n⭕️ 콧대와 턱 라인이 날렵해 보여요",
   "bonusStatus": "마지막 단계",
   "errorMsg": "예기치 못한 상황이 발생했습니다.",
   "resultTitle": "당신의 퍼스널 컬러는",
@@ -215,5 +215,6 @@
   "alertSuccessCopy": "링크 복사 성공! ✨",
   "alertFailCopy": "링크 복사에 실패했어요...🥲",
   "alertMacOS": "macOS 환경의 크롬 브라우저에서는 지원하지 않는 기능입니다. 다른 브라우저에서 실행해 주세요. 🥰",
-  "alertKakao": "카카오 인앱 브라우저에서는 지원하지 않는 기능입니다. 다른 브라우저에서 실행해 주세요. 🥰"
+  "alertKakao": "카카오 인앱 브라우저에서는 지원하지 않는 기능입니다. 다른 브라우저에서 실행해 주세요. 🥰",
+  "alertNotSupportedBrowser": "현재 브라우저에서는 지원하지 않는 기능입니다. 다른 브라우저에서 실행해 주세요. 🥰"
 }

--- a/src/components/AlertModal/style.ts
+++ b/src/components/AlertModal/style.ts
@@ -20,7 +20,6 @@ export const Modal = styled.div`
   background-color: ${({ theme }) => theme.gray[50]};
   color: ${({ theme }) => theme.gray[800]};
 
-  word-break: keep-all;
   white-space: break-spaces;
 
   button {
@@ -31,7 +30,8 @@ export const Modal = styled.div`
 export const Title = styled.h6``;
 
 export const Message = styled.div<{ $textSize: 'sm' | 'md' }>`
-  font-size: ${({ $textSize }) => $textSize === 'sm' && '0.875rem'};
-  text-align: initial;
   margin-bottom: 0.5rem;
+  font-size: ${({ $textSize }) => $textSize === 'sm' && '0.875rem'};
+  line-height: 1.4;
+  text-align: initial;
 `;

--- a/src/pages/result/share.subPage.tsx
+++ b/src/pages/result/share.subPage.tsx
@@ -9,7 +9,7 @@ import kakaoIcon from 'public/images/icon/kakaoIcon.png';
 import ROUTE_PATH from '@Constant/routePath';
 import useKakaoShare from '@Hooks/useKakaoShare';
 import { copyUrl } from '@Utils/clipboard';
-import { webShare } from '@Utils/share';
+import { canWebShare, webShare } from '@Utils/share';
 import { isChrome, isOSX } from '@Utils/userAgent';
 import RestartButton from '@Pages/result/RestartButton';
 import { captureAndDownload, checkIfKakaoAndAlert } from './share.logic';
@@ -67,6 +67,11 @@ function ShareSubPage({
 
     if (isChrome() && isOSX()) {
       setAlertMessage('alertMacOS');
+      return;
+    }
+
+    if (!canWebShare) {
+      setAlertMessage('alertNotSupportedBrowser');
       return;
     }
 


### PR DESCRIPTION
- AlertModal 텍스트 스타일 수정
- `Uncaught (in promise) TypeError: navigator.share is not a function` 에러 핸들링 빠진 부분 추가
  - 기존에 macOS + Chrome 환경에서 에러핸들링했으나 같은 환경에서 개발자도구-모바일 버전으로 실행했을 때 이 에러핸들링에 핸들되지 않아 에러가 그대로 발생하는 현상 발견
  - 따라서 `navigator.share` 타입이 `function`이 아닌 모든 상황을 판단(기존에 `canWebShare` 값으로 선언되어 있음)하여 예외처리하도록 추가

### macOS + Chrome 일반 환경 / 한국어 버전
<img width="350"  alt="alert modal" src="https://github.com/SaekKkanDa/OppaManyColorTone/assets/91963656/eb786d14-3219-46e8-97a4-396c857c3da6">

### macOS + Chrome 개발자도구-모바일 버전 환경 / 영어 버전
<img width="350" alt="alert modal" src="https://github.com/SaekKkanDa/OppaManyColorTone/assets/91963656/c0a204c3-ee3d-4028-9de7-c4f22fab2a92" />
