### PR TITLE
SEO 개선

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://omct.web.app/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>https://omct.web.app/</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/all-types-view</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=springbright</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=springwarm</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=springlight</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=summerlight</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=summercool</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=summermute</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=autumnmute</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=autumnwarm</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=autumndeep</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=winterdeep</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=wintercool</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/result?colorType=winterbright</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://omct.web.app/image-upload</loc>
+  <lastmod>2023-11-05T00:28:50+00:00</lastmod>
+  <priority>0.20</priority>
+</url>
+
+
+</urlset>

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -18,6 +18,7 @@ const App = ({ Component, pageProps }: AppProps) => {
   return (
     <>
       <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>오빠 톤 많아? 퍼스널 컬러 자가진단 테스트</title>
       </Head>
 

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -9,6 +9,7 @@ import GlobalStyle from '@Styles/GlobalStyle';
 import theme from '@Styles/theme';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import { config } from '@fortawesome/fontawesome-svg-core';
+
 config.autoAddCss = false;
 
 const App = ({ Component, pageProps }: AppProps) => {
@@ -17,8 +18,7 @@ const App = ({ Component, pageProps }: AppProps) => {
   return (
     <>
       <Head>
-        <title>오빠 톤 많아? 퍼스널 컬러 자가진단</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>오빠 톤 많아? 퍼스널 컬러 자가진단 테스트</title>
       </Head>
 
       <RecoilRoot>

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -9,7 +9,7 @@ import Document, {
 } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 
-export default class MyDcoument extends Document {
+export default class MyDocument extends Document {
   static async getInitialProps(
     ctx: DocumentContext
   ): Promise<DocumentInitialProps> {
@@ -42,11 +42,22 @@ export default class MyDcoument extends Document {
     return (
       <Html>
         <Head>
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0"
+          />
+
           {/* og tag */}
-          <meta property="og:title" content="오빠 톤 많아?" />
+          <meta
+            property="og:title"
+            content="오빠 톤 많아? 퍼스널 컬러 자가진단"
+          />
           <meta property="og:image" content="/preview/og-image.png" />
           <meta property="og:url" content="https://omct.web.app" />
-          <meta property="og:description" content="퍼스널 컬러 자가진단" />
+          <meta
+            property="og:description"
+            content="퍼스널 컬러 자가진단 온라인 무료 테스트"
+          />
 
           {/* Google Search Console */}
           <meta

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -47,6 +47,23 @@ export default class MyDocument extends Document {
             content="width=device-width, initial-scale=1.0"
           />
 
+          <meta
+            name="application-name"
+            content="오빠 톤 많아? 퍼스널 컬러 자가진단"
+          ></meta>
+          <meta
+            name="msapplication-tooltip"
+            content="오빠 톤 많아? 퍼스널 컬러 자가진단"
+          ></meta>
+          <meta
+            name="description"
+            content="퍼스널 컬러 자가진단 온라인 무료 테스트. 내 퍼스널 컬러는 뭘까? 한 번쯤 궁금한 적 있지 않나요? 하지만 퍼스널 컬러 진단 받으러 가려면 비싸고... 귀찮죠. 내 사진 한 장으로 직접! 비용 없이 빠르고 간편하게! 나의 퍼스널 컬러를 찾아보아요."
+          ></meta>
+          <meta
+            name="keywords"
+            content="퍼스널컬러,퍼스널칼라,퍼스널컬러진단,퍼스널컬러자가진단,퍼스널 컬러,퍼스널 컬러 자가 진단,퍼스널 컬러 테스트,내 퍼스널 컬러,내 퍼스널 컬러 테스트,나의 퍼스널 컬러 찾기,k테스트 퍼스널컬러,personal color,웜톤,쿨톤,봄웜톤,여름쿨톤,가을웜톤,겨울쿨톤,warm,warm tone,cool,cool tone,베스트컬러,베스트칼라,워스트컬러,워스트칼라,톤그로,톤,컬러,칼라,winter personal color,spring personal color,summer personal color,겨울 퍼스널컬러"
+          ></meta>
+
           {/* og tag */}
           <meta
             property="og:title"
@@ -56,8 +73,9 @@ export default class MyDocument extends Document {
           <meta property="og:url" content="https://omct.web.app" />
           <meta
             property="og:description"
-            content="퍼스널 컬러 자가진단 온라인 무료 테스트"
+            content="퍼스널 컬러 자가진단 온라인 무료 테스트. 내 퍼스널 컬러는 뭘까? 한 번쯤 궁금한 적 있지 않나요? 하지만 퍼스널 컬러 진단 받으러 가려면 비싸고... 귀찮죠. 내 사진 한 장으로 직접! 비용 없이 빠르고 간편하게! 나의 퍼스널 컬러를 찾아보아요."
           />
+          <meta property="og:type" content="website"></meta>
 
           {/* Google Search Console */}
           <meta

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -43,11 +43,6 @@ export default class MyDocument extends Document {
       <Html>
         <Head>
           <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0"
-          />
-
-          <meta
             name="application-name"
             content="오빠 톤 많아? 퍼스널 컬러 자가진단"
           ></meta>

--- a/src/pages/result/index.page.tsx
+++ b/src/pages/result/index.page.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import Head from 'next/head';
 import { FormattedMessage } from 'react-intl';
 
 import { createConsecutiveNumbers } from '@Base/utils/arrExtension';
@@ -65,6 +66,13 @@ function ResultPage(): JSX.Element {
 
   return (
     <S.Wrapper>
+      <Head>
+        <link
+          rel="canonical"
+          href="https://omct.web.app/result?colorType=springwarm"
+        />
+      </Head>
+
       <S.ResultContainer ref={resultContainerRef}>
         <S.Title>
           <S.TitleBold color={textColor}>


### PR DESCRIPTION
#232 
# SEO 개선 작업 내용
- `<title>` 및 `<meta>` 태그에 키워드 추가
- 각 컬러 타입에 대한 결과 페이지가 각각 중복된 페이지가 아님을 나타내기 위한 `canonical url` 추가
- `sitemap` 추가
- `sitemap`의 경로를 표시하는 `robots.txt` 추가

# SEO 점수 측정
- [PageSpeed Insights - BEFORE SEO](https://github.com/SaekKkanDa/OppaManyColorTone/files/15443417/omct-local-landing-20230604.pdf), [PageSpeed Insights - AFTER SEO](https://pagespeed.web.dev/analysis/https-omct-web-app/y2cw2qsoyc?form_factor=mobile) **SEO 점수 92점 → 100점**
- [SEO Site Checkup](https://seositecheckup.com/seo-audit/omct.web.app) **SEO 점수 75점 → 80점**