### PR TITLE
ci: firebase-tools 버전 고정 (13.29.1)로 배포 실패 해결

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -54,5 +54,6 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_OPPAMANYCOLORTONE_5FB42 }}'
           channelId: live
           projectId: oppamanycolortone-5fb42
+          firebaseToolsVersion: '13.29.1'
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks


### PR DESCRIPTION
## Summary

Firebase Hosting 배포 워크플로우에서 발생한 JSON 파싱 에러 해결.

## 문제

PR #283 머지 후 자동 배포 워크플로우가 다음 에러로 실패:
\`\`\`
[command]/usr/local/bin/npx firebase-tools@latest deploy --only hosting --project oppamanycolortone-5fb42 --json
...
##[error]Unexpected non-whitespace character after JSON at position 5 (line 2 column 5)
\`\`\`

## 원인

- \`FirebaseExtended/action-hosting-deploy@v0\` 액션이 기본적으로 \`firebase-tools@latest\`를 설치 → 현재 \`15.22.4\` 사용
- Next.js SSR 배포(\`FIREBASE_CLI_EXPERIMENTS: webframeworks\`) 시 firebase-tools 15.x가 \`--json\` 출력에 여러 JSON 블록을 뱉음
- 액션의 파서는 단일 JSON을 기대 → \`position 5 (line 2 column 5)\` 파싱 에러

## 해결

\`firebase-tools\` 버전을 webframeworks + \`--json\` 조합에서 안정적으로 동작하는 \`13.29.1\`로 고정.

\`\`\`yaml
- name: Deploy
  uses: FirebaseExtended/action-hosting-deploy@v0
  with:
    ...
    firebaseToolsVersion: '13.29.1'
\`\`\`

## Test plan

- [ ] 이 PR을 develop로 머지
- [ ] develop → production PR 생성 및 머지
- [ ] production 브랜치 push로 재실행된 workflow가 성공하는지 확인
- [ ] https://omct.web.app/ 에서 이전 PR #282 컬러 팔레트 변경사항이 반영되어 있는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)