### PR TITLE
release: firebase-tools 버전 고정 배포

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -54,5 +54,6 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_OPPAMANYCOLORTONE_5FB42 }}'
           channelId: live
           projectId: oppamanycolortone-5fb42
+          firebaseToolsVersion: '13.29.1'
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks


### PR DESCRIPTION
## Summary

이전 배포 실패 원인이었던 firebase-tools 15.x 파싱 이슈를 해결하기 위한 CI 수정을 production에 반영합니다. 머지되면 자동 배포가 실행되며 이번엔 정상 통과할 것으로 예상됩니다.

## 포함 커밋

- \`3192968\` ci: firebase-tools 버전 고정 (13.29.1) (#284)

## 배경

- PR #283 머지 직후 자동 배포가 \`Unexpected non-whitespace character after JSON at position 5\` 로 실패
- firebase-tools@latest(15.22.4) + Next.js SSR(webframeworks) + \`--json\` 조합의 알려진 이슈
- \`firebase-tools\` 버전을 안정 버전 \`13.29.1\`로 고정 (#284)

## 이전에 함께 배포되어야 하는 변경

이 PR로 자동 배포가 성공하면 이미 develop/production에 병합된 다음 변경사항도 실제 서비스에 반영됩니다:

- #282: 메인 스테이지 컬러 옵션 톤 조정 (7색) + 도메인 문서 추가
- #281: result page global window 접근 시 에러 수정

## Test plan

- [ ] 이 PR 머지 시 실행되는 GitHub Actions workflow 성공 확인
- [ ] https://omct.web.app/ 접속 후 진단 흐름 (랜딩 → 선택 → 결과) 정상 동작 확인
- [ ] choice-color 페이지에서 변경된 컬러(문항 1/4/5/6/9) 렌더링 확인
- [ ] 다국어(ko/en) 로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)