### PR TITLE
feat: 한 눈에 보는 페이지 UI 개선 (기본 활성 타입 + 연예인 카드)

### DIFF
--- a/src/pages/all-types-view/index.page.tsx
+++ b/src/pages/all-types-view/index.page.tsx
@@ -18,11 +18,15 @@ const defaultLabelStyle = {
   fontFamily: "'Noto Sans KR', sans-serif",
 };
 
+const DEFAULT_SELECTED_INDEX = color.findIndex(
+  ({ type }) => type === 'springbright'
+);
+
 const AllTypesView = () => {
   const { t } = useTranslation('common');
 
   const [selectedIndex, setSelectedIndex] = useState<number | undefined>(
-    undefined
+    DEFAULT_SELECTED_INDEX
   );
   const [hoveredIndex, setHoveredIndex] = useState<number | undefined>(
     undefined
@@ -90,6 +94,19 @@ const AllTypesView = () => {
           </S.ColorTypeTitle>
 
           <Tag colorType={colorType} tags={resultColorData[colorType].tags} />
+
+          <S.CelebrityCard borderColor={color[selectedIndex].textColor}>
+            <S.CelebrityImage
+              src={resultColorData[colorType].celebrities[0].imageURL}
+              alt={t(`${colorType}.celebrities.0`)}
+              width={96}
+              height={96}
+            />
+            <S.CelebrityName>
+              {t(`${colorType}.celebrities.0`)}
+            </S.CelebrityName>
+          </S.CelebrityCard>
+
           <S.PaletteGrid>
             {resultColorData[colorType].gridColors.map(
               (backgroundColor, index) => (

--- a/src/pages/all-types-view/style.ts
+++ b/src/pages/all-types-view/style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import Image from 'next/image';
 import { flexCustom, layout } from '@Styles/theme';
 import { PieChart as _PieChart } from 'react-minimal-pie-chart';
 
@@ -65,6 +66,29 @@ export const Tag = styled.span<TagStyleProps>`
   color: ${({ theme, textColor }) =>
     ({ light: theme.white, dark: theme.gray[900] }[textColor])};
   font-size: 14px;
+`;
+
+export const CelebrityCard = styled.div<{ borderColor: string }>`
+  ${flexCustom('column', 'center', 'center')}
+  row-gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border: 1.5px solid ${({ borderColor }) => borderColor};
+  border-radius: 12px;
+  background-color: ${({ theme }) => theme.white};
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+`;
+
+export const CelebrityImage = styled(Image)`
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+export const CelebrityName = styled.span`
+  color: ${({ theme }) => theme.gray[700]};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: 500;
 `;
 
 export const PaletteGrid = styled.div`


### PR DESCRIPTION
## Summary

한 눈에 보는 페이지(\`/all-types-view\`) UX 개선.

- 페이지 진입 시 아무 타입도 선택되지 않아 빈 안내 문구만 보이던 문제 해결
- 각 타입의 대표 연예인을 시각적으로 확인할 수 있도록 카드 추가

## 변경 사항

### 1. 기본 활성 타입: 봄 브라이트
- \`selectedIndex\` 초기값을 \`color\` 배열에서 \`springbright\` 인덱스로 계산해서 설정
- 진입 즉시 파이차트에서 봄 브라이트 강조, 하단 정보(타입명/태그/연예인/팔레트)가 노출됨

\`\`\`ts
const DEFAULT_SELECTED_INDEX = color.findIndex(
  ({ type }) => type === 'springbright'
);
\`\`\`

### 2. 파이차트 하단 연예인 카드 (1명)
- 위치: 태그(\`Tag\`)와 팔레트 그리드(\`PaletteGrid\`) 사이
- 데이터: \`resultColorData[colorType].celebrities[0]\` (기존 결과 페이지와 동일 데이터)
- 스타일:
  - 96×96 원형 이미지 (\`next/image\`)
  - 이름 라벨
  - 카드 테두리 색상 = 해당 타입의 \`textColor\`로 강조
  - 흰 배경 + 은은한 그림자

### 3. 다국어 대응
- 이름은 기존 번역 키 \`\${colorType}.celebrities.0\` 재사용 → ko/en 모두 자동 지원
- 신규 번역 키 추가 없음

## Test plan

- [ ] 로컬(\`yarn dev\`)에서 \`/all-types-view\` 접속 시 봄 브라이트가 기본 선택되어 있는지
- [ ] 파이차트에서 다른 타입 클릭 시 연예인 카드가 해당 타입 인물로 갱신되는지
- [ ] 선택 해제 시 안내 문구(\`clickType\`)로 원복되는지
- [ ] 12타입 모두에서 이미지·이름·팔레트가 정상 렌더링되는지
- [ ] 다국어 (ko/en) 전환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)