### PR TITLE
fix(adsense): 스크립트 중복 로드 제거 및 미사용 import 정리

### DIFF
--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -108,10 +108,6 @@ export default class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
-          <script
-            async
-            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9551977219354865"
-          />
         </body>
       </Html>
     );

--- a/src/pages/choice-color/index.page.tsx
+++ b/src/pages/choice-color/index.page.tsx
@@ -4,7 +4,6 @@ import choiceColorData, { ChoiceColorDataType } from '@Data/choiceColorData';
 import BasicStage from './BasicStage';
 import BonusStage from './BonusStage';
 import * as S from './style';
-import { AdSense } from '@Components/AdSense';
 import useCropImg from '@Hooks/useCropImg';
 import shuffle from '@Utils/shuffle';
 import { useSearchParams } from 'next/navigation';


### PR DESCRIPTION
## Summary

결과 페이지 하단 여백 이슈를 조사하다 AdSense 관련 두 가지 이슈를 발견해 정리합니다.

## 문제

### 1. AdSense 스크립트 중복 로드
같은 \`adsbygoogle.js\`가 두 곳에서 로드되고 있었음:

- \`src/pages/_app.page.tsx:53-57\` — \`next/script\` async
- \`src/pages/_document.page.tsx:111-114\` — raw \`<script>\` async

Google AdSense는 스크립트가 여러 번 로드되면 \`TagError: adsbygoogle.push() error: Only one AdSense head tag supported per page.\` 를 뱉으며 광고 로드가 실패할 수 있습니다. 실제로 프로덕션에서 광고가 안 뜨는 현상의 유력한 원인 중 하나로 추정.

### 2. 사용 안 하는 AdSense import
\`src/pages/choice-color/index.page.tsx\` 상단에서 \`AdSense\`를 import하고 있으나 JSX에서 사용하지 않음. 이전 리팩터링 이후 렌더링에서 빠졌으나 import만 남은 상태였고, \`no-unused-vars\` ESLint 경고를 유발.

## 남은 후속 작업 (이 PR 범위 외)

이번 정리 후에도 광고가 안 뜨면 다음이 원인 후보입니다:

1. **로컬 환경**: \`localhost\`에서 AdSense는 광고 미노출이 정상. 실 도메인 https://omct.web.app 에서만 뜸.
2. **AdSense 콘솔 상태**: 사이트 승인/정책 위반/광고 슬롯(\`2551404503\`) 활성 상태 점검 필요.
3. **하단 여백**: 광고가 안 뜨는 경우 100px 예약 공간이 여백으로 보임 → 별도 PR로 스타일 조정 계획.

## Test plan

- [ ] 로컬(\`yarn dev\`)에서 정상 컴파일 확인
- [ ] 프로덕션 배포 후 https://omct.web.app/result?colorType=springbright 에서 브라우저 DevTools > Network에 \`adsbygoogle.js\` 요청이 **1건만** 뜨는지 확인
- [ ] Console에 \`Only one AdSense head tag supported per page.\` 에러가 사라졌는지 확인
- [ ] 광고가 실제로 노출되는지 확인 (안 뜨면 위 후속 작업 항목 점검)

🤖 Generated with [Claude Code](https://claude.com/claude-code)