### PR TITLE
ci: firebase-tools 13.29.1 → 13.35.1 (Node 22 배포 실패 해결)

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -54,6 +54,6 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_OPPAMANYCOLORTONE_5FB42 }}'
           channelId: live
           projectId: oppamanycolortone-5fb42
-          firebaseToolsVersion: '13.29.1'
+          firebaseToolsVersion: '13.35.1'
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks


### PR DESCRIPTION
## Summary

PR #289 머지 후 자동 배포가 인증 단계에서 실패. Node 22 + firebase-tools 13.29.1 호환성 이슈로 확인되어 firebase-tools 버전을 상향.

## 문제

Deploy 스텝 로그에서 다음 에러:

\`\`\`
[command]/usr/local/bin/npx firebase-tools@13.29.1 deploy --only hosting ...
##[group]Setting up CLI credentials
Created a temporary file with Application Default Credentials.  ← 시크릿은 정상 전달
...
Invalid response body while trying to fetch https://www.googleapis.com/oauth2/v4/token: Premature close
Error: Failed to authenticate, have you run firebase login?
\`\`\`

시크릿(\`FIREBASE_SERVICE_ACCOUNT_...\`)은 정상적으로 서비스 계정 파일로 만들어졌으나, Google OAuth 토큰 교환 요청이 HTTP 조기 종료로 실패.

## 원인

Node 22의 undici HTTP 클라이언트와 firebase-tools 13.29.1이 내장한 구 \`google-auth-library\`의 keep-alive 처리 호환성 문제로 추정.

증거:
- PR #285 (Node 20 + firebase-tools 13.29.1): ✅ 성공
- PR #289 (Node 22 + firebase-tools 13.29.1): ❌ Premature close

Node 20/22 사이에서 firebase-tools 만 그대로 → 문제 발생 = 라이브러리 상향 필요.

## 변경

\`\`\`diff
- firebaseToolsVersion: '13.29.1'
+ firebaseToolsVersion: '13.35.1'
\`\`\`

13.x 최신 마이너로 상향해 Node 22 대응이 반영된 auth 관련 트랜지티브 의존성 갱신. 15.x는 JSON 파싱 이슈(PR #284 참조)가 있어 회피.

## Test plan

- [ ] 이 PR을 develop로 머지
- [ ] develop → production PR 생성 및 머지
- [ ] production 자동 배포 워크플로우 성공 확인
- [ ] https://omct.web.app/ 접속 후 PR #289의 변경사항 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)