### PR TITLE
release: firebase-tools 13.35.1 (Node 22 auth 호환 수정)

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -54,6 +54,6 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_OPPAMANYCOLORTONE_5FB42 }}'
           channelId: live
           projectId: oppamanycolortone-5fb42
-          firebaseToolsVersion: '13.29.1'
+          firebaseToolsVersion: '13.35.1'
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks


### PR DESCRIPTION
## Summary

직전 배포(PR #289 머지 트리거)가 Node 22 + firebase-tools 13.29.1의 auth 호환 이슈로 실패. firebase-tools를 13.35.1로 상향한 수정을 production에 반영해 재배포합니다.

## 포함 커밋

- \`fc94192\` ci: firebase-tools 13.29.1 → 13.35.1 (Node 22 auth 호환) (#290)

## 배경

PR #289 (Node 20 → 22 + TS 5.9 등)가 develop → production까지 머지됐지만 자동 배포 워크플로우가 인증 단계에서 실패:

\`\`\`
Invalid response body while trying to fetch https://www.googleapis.com/oauth2/v4/token: Premature close
Error: Failed to authenticate, have you run firebase login?
\`\`\`

Node 22의 undici HTTP 스택과 firebase-tools 13.29.1이 내장한 구 \`google-auth-library\` 호환성 이슈로 확인. firebase-tools를 13.x 최신 마이너(13.35.1)로 상향해 auth 관련 트랜지티브 의존성 갱신 (#290).

## 함께 배포되는 이전 변경사항

이번 배포가 성공하면 지난 실패한 배포에 포함되었던 다음 변경사항도 함께 실 서비스에 반영됩니다:

- \`#286\` 한 눈에 보는 페이지 개선 (봄 브라이트 기본 활성 + 연예인 카드)
- \`#287\` AdSense 스크립트 중복 로드 제거
- \`#288\` 결과 페이지 하단 여백 축소 + Node 22 & TS 5.9 업그레이드 + 이미지 화질 개선

## Test plan

- [ ] 이 PR 머지 시 실행되는 GitHub Actions workflow 성공 확인 (Deploy 스텝 통과)
- [ ] https://omct.web.app/ 접속 후 랜딩 → 진단 → 결과 흐름 정상 확인
- [ ] \`/all-types-view\` 봄 브라이트 기본 활성 & 연예인 카드 확인
- [ ] 이미지 업로드 → 결과 페이지 팔레트에서 이미지 화질 개선 확인 (Retina)
- [ ] Console에 \`Only one AdSense head tag supported per page.\` 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)