### PR TITLE
ci: Node 22 배포 auth 재실패 대응 (firebase-tools 14 + 액션 v4)

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Read .nvmrc
         id: node_version
-        run: echo ::set-output name=NODE_VERSION:$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{steps.node_version.outputs.NODE_VERSION}}
 
@@ -54,6 +54,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_OPPAMANYCOLORTONE_5FB42 }}'
           channelId: live
           projectId: oppamanycolortone-5fb42
-          firebaseToolsVersion: '13.35.1'
+          firebaseToolsVersion: '14.11.1'
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks
+          NODE_OPTIONS: '--dns-result-order=ipv4first'


### PR DESCRIPTION
## Summary

PR #290 (firebase-tools 13.35.1) 배포 후에도 동일한 \`Premature close\` 에러 지속. Node 22 + firebase-tools 13.x 조합 이슈 확정으로 판단하여 14.x로 상향 + 알려진 워크어라운드 병행. 겸사겸사 액션 deprecation 경고까지 정리.

## 문제

PR #290 머지 후 배포 실패:

\`\`\`
[command]/usr/local/bin/npx firebase-tools@13.35.1 deploy --only hosting ...
Error: Invalid response body while trying to fetch https://www.googleapis.com/oauth2/v4/token: Premature close
Error: Failed to authenticate, have you run firebase login?
\`\`\`

또한 런타임 경고:
\`\`\`
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24:
actions/checkout@v3, actions/setup-node@v3
\`\`\`

## 원인 정리

1. **Auth 실패**: Node 22의 undici HTTP 스택 + firebase-tools 13.x가 내장한 구 \`google-auth-library\`의 keep-alive/OAuth 토큰 교환 이슈. 13.29.1 → 13.35.1 소폭 마이너 업 정도로는 해결 안 됨.
2. **액션 deprecation**: GitHub 런너가 2025-09-19 부로 Node 20을 지원 중단, 런타임을 Node 24로 강제 실행. \`actions/checkout@v3\`, \`actions/setup-node@v3\`는 Node 20 타겟이라 강제 마이그레이션됨.
3. **\`::set-output\` deprecated**: 2022년부터 사용 중단 예고된 문법, 새 문법(\`$GITHUB_OUTPUT\`)으로 교체 필요.

## 변경 상세

### 1) firebase-tools 13.35.1 → 14.11.1
\`\`\`diff
-    firebaseToolsVersion: '13.35.1'
+    firebaseToolsVersion: '14.11.1'
\`\`\`
14.x 는 \`google-auth-library\` / \`gaxios\` 신버전 (Node 22의 undici 대응 반영). 15.x는 \`--json\` 파싱 이슈(PR #284 참조) 있어 회피.

### 2) NODE_OPTIONS 워크어라운드
\`\`\`diff
      env:
        FIREBASE_CLI_EXPERIMENTS: webframeworks
+       NODE_OPTIONS: '--dns-result-order=ipv4first'
\`\`\`
Node 22 부터 기본 IPv6 우선 DNS 해석이 활성화. 일부 Google 서비스 엔드포인트에서 IPv6로 연결 시 조기 종료되는 사례가 보고됨. IPv4 우선으로 회귀시켜 안정성 확보.

### 3) 액션 v3 → v4
\`\`\`diff
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
...
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
\`\`\`
Node 24 런타임 지원 버전.

### 4) \`::set-output\` → \`$GITHUB_OUTPUT\`
\`\`\`diff
-        run: echo ::set-output name=NODE_VERSION:$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
\`\`\`

## Test plan

- [ ] develop 머지
- [ ] develop → production PR 생성 및 머지
- [ ] 자동 배포 워크플로우가 auth 통과 후 build/deploy 완료
- [ ] https://omct.web.app/ 반영 확인
- [ ] deprecation 경고 사라짐

## 백업 플랜

이번에도 auth 실패 시:
- (a) \`firebase-tools@15\` 시도 후 \`--json\` 파싱 이슈 재발하면 별도 대응
- (b) \`firebase login:ci\` 로 CI 토큰 발급 → \`FIREBASE_TOKEN\` 시크릿 추가 → OAuth 교환 자체를 우회

🤖 Generated with [Claude Code](https://claude.com/claude-code)