### PR TITLE
release: Node 22 배포 auth 재실패 대응 (firebase-tools 14 + 액션 v4)

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Read .nvmrc
         id: node_version
-        run: echo ::set-output name=NODE_VERSION:$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{steps.node_version.outputs.NODE_VERSION}}
 
@@ -54,6 +54,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_OPPAMANYCOLORTONE_5FB42 }}'
           channelId: live
           projectId: oppamanycolortone-5fb42
-          firebaseToolsVersion: '13.35.1'
+          firebaseToolsVersion: '14.11.1'
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks
+          NODE_OPTIONS: '--dns-result-order=ipv4first'


### PR DESCRIPTION
## Summary

직전 배포 재시도(PR #291)도 firebase-tools 13.35.1의 Node 22 auth 이슈로 실패. firebase-tools 14.11.1 + NODE_OPTIONS 워크어라운드 + 액션 v4 업데이트를 production에 반영해 재재배포합니다.

## 포함 커밋

- \`77fae84\` ci: Node 22 배포 auth 재실패 대응 및 액션/문법 업데이트 (#292)

## 이번 릴리즈의 변경사항

CI 워크플로우(\`.github/workflows/firebase-hosting-merge.yml\`) 단일 파일:

1. **firebase-tools 13.35.1 → 14.11.1** — Node 22 undici / OAuth 교환 이슈 대응
2. **NODE_OPTIONS: --dns-result-order=ipv4first** — 안전망
3. **actions/checkout@v3 → v4**, **actions/setup-node@v3 → v4** — Node 20 deprecation 해소
4. **::set-output → \$GITHUB_OUTPUT** — 신 문법 마이그레이션

## 함께 배포되는 이전 변경사항

이번 배포가 성공하면 지난 실패한 배포들에 포함되었던 다음 변경사항이 실 서비스에 반영됩니다:

- \`#286\` 한 눈에 보는 페이지 개선 (봄 브라이트 기본 활성 + 연예인 카드)
- \`#287\` AdSense 스크립트 중복 로드 제거
- \`#288\` 결과 페이지 하단 여백 축소 + Node 22 & TS 5.9 업그레이드 + 이미지 화질 개선
- \`#290\` firebase-tools 13.35.1 (Node 22 초기 대응, 여전히 부족했음)
- \`#292\` firebase-tools 14 + 액션 v4 + NODE_OPTIONS (이번 릴리즈의 핵심)

## Test plan

- [ ] 이 PR 머지 시 실행되는 GitHub Actions workflow 성공 확인 (Deploy 스텝 auth 통과)
- [ ] deprecation 경고 사라짐 확인
- [ ] https://omct.web.app/ 접속 후 이전 변경사항 반영 확인:
  - [ ] \`/all-types-view\` 봄 브라이트 기본 활성 + 연예인 카드
  - [ ] 결과 페이지 하단 여백 축소 + Palette 이미지 화질 개선 (Retina)
  - [ ] 이미지 업로드 화질 개선
  - [ ] AdSense 스크립트 중복 없음 (Network 탭 확인)

## 백업 플랜

이번에도 auth 실패 시:
- \`firebase-tools@15\` 상향 (\`--json\` 파싱 이슈 대응 필요할 수도)
- \`FIREBASE_TOKEN\` 기반 인증으로 OAuth 교환 우회

🤖 Generated with [Claude Code](https://claude.com/claude-code)