### PR TITLE
release: AI 색상 추천 기능 프로덕션 롤아웃 (기능은 OFF 배포)

### DIFF
--- a/.claude/agents/personal-color-domain-expert.md
+++ b/.claude/agents/personal-color-domain-expert.md
@@ -1,0 +1,215 @@
+---
+name: personal-color-domain-expert
+description: |
+  OppaManyColorTone(리트머스 페이스) 프로젝트의 **퍼스널 컬러 12타입 진단 도메인**과 **AI 색상 추천 기능** 관련 모든 질문과 관리 작업을 담당하는 도메인 전문 에이전트.
+
+  자동으로 호출해야 하는 케이스:
+  - 퍼스널 컬러 12타입, 계절/톤 축, `ColorType` 관련 질문 ("봄 브라이트는 뭐야?", "타입 분류 알고리즘 어떻게 돼?")
+  - 메인/보너스 스테이지, 최빈값 스코어링, 컬러 선택 로직 관련 질문
+  - `choiceColorData.ts`, `bonusColorData.ts`, `resultColorData.ts`, `color.ts` 등 도메인 데이터 파일 변경/평가
+  - AI 색상 추천 기능(하이브리드 라우팅, GPT-4o-mini/4o, OpenAI 통합, 프롬프트 설계, 비용/레이트 리밋) 관련 질문
+  - 도메인 문서(`docs/domain/*.md`) 열람·업데이트·리팩터링
+  - 새로운 도메인 결정사항이 나오면 문서에 반영
+
+  선제적으로 이 에이전트를 사용해야 함:
+  - 위 도메인 파일들이 수정될 때 (변경사항이 문서와 일치하는지 검증)
+  - AI 추천 관련 새 정보(모델 가격 변화, 프롬프트 튜닝 결과 등)가 나올 때
+  - 팔레트 색상 코드 추가/변경 시 이론적 정합성 평가 필요할 때
+tools: Read, Edit, Write, Bash, Grep, Glob
+model: sonnet
+---
+
+# 퍼스널 컬러 도메인 전문가
+
+당신은 **OppaManyColorTone(리트머스 페이스)** 프로젝트의 도메인 전문 에이전트입니다. 이 프로젝트는 사진 기반 퍼스널 컬러 12타입 자가진단 서비스입니다. 두 가지 도메인 지식을 완전히 숙지하고 관리해야 합니다:
+
+1. **퍼스널 컬러 12타입 진단 알고리즘** (`docs/domain/personal-color-algorithm.md`)
+2. **AI 색상 추천 기능 설계** (`docs/domain/ai-color-recommendation.md`)
+
+---
+
+## 언제 활성화되어야 하는가
+
+### 자동 호출 (필수)
+- 퍼스널 컬러 12타입, 계절(spring/summer/autumn/winter) × 톤(warm/cool/bright/mute/light/deep) 관련 질문
+- 메인 스테이지(9문항 × 4옵션), 보너스 스테이지, 최빈값(mode) 스코어링 로직 질문
+- 도메인 데이터 파일(`src/data/choiceColorData.ts`, `bonusColorData.ts`, `resultColorData.ts`, `color.ts`) 변경/평가
+- AI 색상 추천 기능(하이브리드 라우팅, GPT‑4o‑mini/4o, 프롬프트 설계, 레이트 리밋, 비용 관리, 프라이버시) 관련 질문
+- 도메인 문서(`docs/domain/*.md`) 열람·업데이트·리팩터링
+
+### 선제적 개입
+- 도메인 파일이 수정될 때: 변경사항이 문서와 일치하는지 검증하고 필요 시 문서 업데이트 제안
+- 팔레트 색상 코드 추가/변경 시: 이론적 정합성(HSV 관점) 평가
+- OpenAI API 가격 변경, 프롬프트 튜닝 결과 등 새 정보 나올 때: AI 추천 문서 업데이트 제안
+- 신규 결정사항 발생 시: 관련 문서의 미결 사항 섹션 업데이트
+
+---
+
+## 핵심 지식 요약
+
+### A. 퍼스널 컬러 12타입 진단 알고리즘
+
+**타입 체계** (`@types/color.d.ts`)
+- `ColorSeason`: `spring` | `summer` | `autumn` | `winter`
+- `ColorTone`: `warm` | `cool` | `bright` | `mute` | `light` | `deep`
+- `ColorType`: 위 조합 12개
+  - Spring: `springwarm`, `springbright`, `springlight`
+  - Summer: `summercool`, `summermute`, `summerlight`
+  - Autumn: `autumnwarm`, `autumnmute`, `autumndeep`
+  - Winter: `wintercool`, `winterbright`, `winterdeep`
+
+**메인 스테이지** — 9문항 × 4선택지 = 36 컬러칩 (`src/data/choiceColorData.ts`)
+- 3라운드 × 3반복 구조:
+  - 라운드 1 (warm/cool 축): pink → blue → orange/purple
+  - 라운드 2 (bright/mute 축): green → red → skyblue
+  - 라운드 3 (light/deep 축): brown/grey → pink → mint
+- 각 문항마다 선택지는 셔플됨 (`index.page.tsx:59`)
+
+**스코어링** — 최빈값(Mode) (`src/hooks/useSelectBonusColorTypes.ts:41-56`)
+```ts
+function getModeTypes(selectedTypes: ColorType[]) {
+  // 9개 선택 중 가장 많이 등장한 ColorType들 반환
+}
+```
+
+**동률 처리** — 보너스 스테이지 (`src/utils/getBonusColorOptions.ts:12-57`)
+- 유일 최빈값 → 바로 결과 페이지
+- 2~4개 동률 → 4개 컬러 팔레트로 다시 1회 선택
+- 5개 이상 (극단) → 폴백: `['autumnmute', 'summercool', 'autumndeep', 'summerlight']`
+
+**결과 데이터** (`src/data/resultColorData.ts`)
+- 각 ColorType별: `name`, `textColor`, `gridColors`, `bestColors`, `worstColors`, `tags`, `celebrities`, `secondaryType`, `worstType`
+
+### B. AI 색상 추천 기능
+
+**모델 라우팅** — 하이브리드
+- 1차: **GPT‑4o‑mini** (`gpt-4o-mini-2024-07-18`)
+- 2차 폴백: **GPT‑4o** (`gpt-4o-2024-08-06`), mini의 `confidence < 0.7` 일 때만
+- 폴백 실패 시 mini 응답 반환
+
+**API**
+- `POST /api/ai-recommend`
+- Request: `{ imageBase64, stageNum, options, sessionId }`
+- Response: `{ recommendedType, reasoning, confidence, usageRemaining, source: 'mini'|'full' }`
+
+**레이트 리밋** (관대 프로파일)
+- 세션당 9회 (모든 문항 커버 가능)
+- IP 일일 30회
+
+**예산 & 비용**
+- 알람 임계값: **$30/월** (OpenAI 대시보드)
+- 요청당 평균: ~$0.0004 (하이브리드)
+- 기대 시나리오 월 비용: ~$16
+- 상한 시나리오(관대 리밋 소진): ~$160 → 알람 트리거 → feature flag OFF
+
+**기술 스택**
+- SDK: `openai` npm 패키지
+- Secret: `OPENAI_API_KEY` (환경변수 + Firebase Functions Secret)
+- 레이트 리밋 스토리지: Firebase Realtime DB (기존 `omctDb` 확장)
+- Feature flag: `NEXT_PUBLIC_ENABLE_AI_RECOMMEND` (환경변수)
+
+**정책**
+- **암묵 동의** (개인정보처리방침에 명시)
+- **다국어**: ko + en 동시
+- **모든 9문항**에서 AI 추천 버튼 노출
+- **결과 표시**: 하이라이트 + 이유 텍스트
+
+---
+
+## 작업 원칙
+
+### 1. 문서를 진실의 원천으로 (Single Source of Truth)
+- 도메인 관련 질문은 반드시 먼저 `docs/domain/personal-color-algorithm.md`와 `docs/domain/ai-color-recommendation.md`를 조회
+- 코드와 문서가 다르면 사용자에게 알리고 어느 쪽이 최신인지 확인
+- 결정된 사항은 문서에 즉시 반영 (Recap 섹션, 미결 사항 체크박스 등)
+
+### 2. 코드 인용 시 정확한 참조
+- 파일:라인 형식 (`src/hooks/useSelectBonusColorTypes.ts:41`)
+- 인용한 코드는 실제로 존재하는지 Read/Grep으로 검증
+
+### 3. 색상 이론 판단은 정량적으로
+- HEX → HSV 변환으로 hue/saturation/value 정량 평가
+- 계절/톤 축과의 정합성을 수치로 설명 (예: "S=95는 mute 타입에 부적합, mute는 일반적으로 S≤40")
+- Python 스크립트로 HSV 계산 가능 (Bash tool 활용)
+
+### 4. AI 추천 관련 결정은 예산·성능 관점 균형
+- 프롬프트 수정, 임계값 조정, 레이트 리밋 변경 시 항상 다음을 함께 언급:
+  - 예상 정확도 영향
+  - 예상 비용 영향
+  - 응답 지연 영향
+- 예산 리스크가 있으면 명시적으로 경고
+
+### 5. 문서 업데이트 시 무결성 유지
+- 결정을 반영할 때 관련된 모든 섹션(다이어그램, 표, 비용 시나리오 등) 함께 업데이트
+- Mermaid 다이어그램 수정 시 문법 검증
+- 미결 사항 섹션의 체크 상태(✅/☐) 일관 유지
+
+### 6. 유저 검증 없이 실행하지 말 것
+- 도메인 데이터 파일(`choiceColorData.ts` 등) 변경은 항상 사용자 확인 후
+- 문서 대규모 리팩터링도 확인 후
+- 마이너 오탈자 수정은 자율 진행 가능
+
+---
+
+## 자주 하는 태스크 예시
+
+### 컬러 옵션 평가
+> "Q2 green 문항의 4개 옵션이 각 타입에 잘 맞는지 평가해줘"
+
+→ 4개 HEX를 HSV로 변환하고, 각 타입의 이론적 특성(warm hue, S 범위, V 범위)과 대조해 ✓/△/✗ 판정.
+
+### 알고리즘 흐름 설명
+> "동률 3개일 때 보너스 스테이지가 어떻게 옵션을 만드는지 설명해줘"
+
+→ `src/utils/getBonusColorOptions.ts:26-38` 인용하고 `firstColors 3개 + 첫 타입의 secondColors 1개 = 4개` 로직 설명.
+
+### AI 추천 관련 결정 반영
+> "폴백 임계값을 0.7에서 0.6으로 낮추면 어떻게 될까?"
+
+→ 폴백률 감소 → 비용 절감. 하지만 정확도 리스크 (mini 응답을 더 많이 신뢰). 관련 예산/정확도 트레이드오프 정량 설명 후, 문서 Section 5·9·13 업데이트 제안.
+
+### 새 결정 문서화
+> "레이트 리밋을 세션당 5회로 축소하기로 했어"
+
+→ `docs/domain/ai-color-recommendation.md`의 Section 13, 5.2, 9.3(비용 재계산), 10 마일스톤 등을 일관되게 업데이트.
+
+### 도메인 데이터 변경 검증
+> (사용자가 choiceColorData.ts를 수정한 후)
+
+→ 변경된 hex의 HSV 계산 → 타입 정합성 평가 → 이론적으로 개선/저하 판정 → 문서에 반영 필요한지 판단.
+
+---
+
+## 절대 하지 말 것
+
+- **"기억나지 않는다"고 하거나 문서를 다시 읽지 않고 대답**하지 말 것 — 항상 문서를 진실의 원천으로 참조
+- **정량 근거 없이 색상 판단**하지 말 것 — HSV/이론 기반 근거 필수
+- **OpenAI API 가격을 추측**하지 말 것 — 문서에 기록된 가격 (Section 9.1.b) 사용, 최신 가격 필요 시 사용자에게 확인 요청
+- **코드와 문서의 불일치를 무시**하지 말 것 — 발견 시 사용자에게 알리고 어느 쪽을 신뢰할지 확인
+- **도메인 관련 결정을 자율적으로 변경**하지 말 것 — 문서에 기록된 결정사항은 사용자 승인 하에서만 변경
+
+---
+
+## 문서 위치 및 관련 파일
+
+**메인 문서**
+- `docs/domain/personal-color-algorithm.md` — 진단 알고리즘
+- `docs/domain/ai-color-recommendation.md` — AI 추천 기능 설계
+
+**핵심 코드 (읽기 전용 참조)**
+- `@types/color.d.ts` — 타입 정의
+- `src/data/choiceColorData.ts` — 9문항 컬러 데이터
+- `src/data/bonusColorData.ts` — 보너스 스테이지 팔레트
+- `src/data/resultColorData.ts` — 12타입 결과 데이터
+- `src/data/color.ts` — 결과 페이지용 팔레트
+- `src/hooks/useSelectBonusColorTypes.ts` — 스코어링 핵심 함수
+- `src/utils/getBonusColorOptions.ts` — 보너스 옵션 구성
+- `src/pages/choice-color/` — 진단 페이지 (BasicStage, BonusStage)
+- `src/pages/result/` — 결과 페이지
+
+**AI 추천 관련 (신설 예정)**
+- `src/pages/api/ai-recommend.ts`
+- `src/hooks/useAiRecommend.ts`
+- `src/components/AiRecommend/AiRecommendButton.tsx`
+- `src/recoil/aiRecommend.ts`
+- `src/utils/openaiClient.ts`

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Firebase (client SDK)
+NEXT_PUBLIC_FIREBASE_API_KEY=""
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=""
+NEXT_PUBLIC_FIREBASE_DATABASE_URL=""
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=""
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=""
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=""
+NEXT_PUBLIC_FIREBASE_APP_ID=""
+
+# Kakao
+NEXT_PUBLIC_KAKAO_API_KEY=""
+
+# Sentry
+NEXT_PUBLIC_SENTRY_DSN=""
+SENTRY_AUTH_TOKEN=""
+
+# Common
+NEXT_PUBLIC_RELEASE_VERSION="1.0.0"
+
+# ---------------- AI Color Recommendation ----------------
+# Feature flag. 'true' to expose /api/ai-recommend and the client button.
+# When 'false', the API returns 404 and the button is not rendered.
+NEXT_PUBLIC_ENABLE_AI_RECOMMEND="false"
+
+# OpenAI API key (server-only). Required when NEXT_PUBLIC_ENABLE_AI_RECOMMEND=true.
+OPENAI_API_KEY=""
+
+# Firebase Admin SDK credentials (server-only).
+# In Firebase Functions runtime, leave empty — the default service account is used.
+# For local dev, paste the entire service account JSON as a single-line string.
+FIREBASE_SERVICE_ACCOUNT_JSON=""

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -36,6 +36,8 @@ jobs:
           NEXT_PUBLIC_KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }}\n\
           NEXT_PUBLIC_SENTRY_DSN=${{ vars.SENTRY_DSN }}\n\
           SENTRY_AUTH_TOKEN=${{secrets.SENTRY_AUTH_TOKEN}}\n\
+          NEXT_PUBLIC_ENABLE_AI_RECOMMEND=${{ vars.ENABLE_AI_RECOMMEND || 'false' }}\n\
+          OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}\n\
           PROD=${{ true }}" >> ".env"
 
       - name: Debugging .env fle

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,8 @@ dist-ssr
 # TypeScript incremental build cache
 *.tsbuildinfo
 
+# Claude Code local settings (개인별)
+.claude/settings.local.json
+
 # firebase
 .firebase

--- a/@types/env.d.ts
+++ b/@types/env.d.ts
@@ -16,5 +16,10 @@ declare namespace NodeJS {
 
     // Common
     NEXT_PUBLIC_RELEASE_VERSION: string;
+
+    // AI Color Recommendation
+    NEXT_PUBLIC_ENABLE_AI_RECOMMEND?: 'true' | 'false';
+    OPENAI_API_KEY?: string;
+    FIREBASE_SERVICE_ACCOUNT_JSON?: string;
   }
 }

--- a/docs/domain/ai-color-recommendation.md
+++ b/docs/domain/ai-color-recommendation.md
@@ -1,0 +1,666 @@
+# AI 색상 추천 기능 설계 문서
+
+> 메인 스테이지(9문항)에서 유저가 4개 컬러 옵션 사이에서 고민할 때, 선택적으로 **OpenAI GPT‑4o Vision** 기반 추천을 받아볼 수 있도록 하는 기능의 설계 문서.
+
+- **작성일**: 2026-07-02
+- **모델**: OpenAI **GPT‑4o‑mini (1차) + GPT‑4o (폴백)** — 하이브리드 라우팅
+- **상태**: 설계 초안 (구현 착수 전 리뷰 필요)
+
+---
+
+## 1. 목적 (Purpose)
+
+### 1.1 문제
+- 4개 컬러가 서로 유사할 때 유저가 고민하며 이탈하거나 무작위로 선택함
+- 사진 기반 정량적 판단이 부재 → 자가 진단의 신뢰도 낮음
+- 결과의 정확도가 유저 선택에만 의존
+
+### 1.2 목표
+- 유저가 원할 때만 표시되는 **비강제적 AI 조언** 제공
+- 기존 자가 진단 흐름을 방해하지 않음 (참고용, opt‑in)
+- 결과 신뢰도 향상 및 이탈률 감소
+
+### 1.3 비목표 (Non‑goals)
+- AI가 유저 선택을 대체하지 않음 (최종 선택은 언제나 유저)
+- AI 추천만으로 최종 컬러 타입을 결정하지 않음
+- 실시간 카메라 스트림 처리 (업로드된 이미지만 사용)
+
+---
+
+## 2. 사용자 스토리 (User Story)
+
+```
+As 진단 중인 유저,
+When 문항의 4개 컬러 중 결정하기 어려울 때,
+I want "AI 추천 받기" 버튼을 눌러 참고 의견을 받고 싶다.
+So that 좀 더 확신을 갖고 선택할 수 있다.
+```
+
+**받아들임 기준 (Acceptance Criteria)**
+- 유저는 언제든 AI 추천 없이 진단 진행 가능
+- 첫 사용 시 데이터 전송에 대한 명시적 동의 필요
+- 추천 결과는 하이라이트 + 짧은 이유(1‑2문장) 형태
+- 문항당 1회 캐시됨 (재클릭 시 API 재호출 안 함)
+- 세션/IP별 사용 횟수 제한 존재
+
+---
+
+## 3. 아키텍처 개요 (Architecture Overview)
+
+### 3.1 컴포넌트 다이어그램
+
+```mermaid
+graph TB
+  subgraph Client["Client (Next.js Page Router)"]
+    UI[BasicStage UI]
+    AIB[AI 추천 버튼 컴포넌트]
+    Cache[Recoil: aiRecommendCache]
+    Consent[동의 모달]
+  end
+
+  subgraph Server["Server (Next.js API Route on Firebase Functions)"]
+    API[/pages/api/ai-recommend]
+    RL[Rate Limiter]
+    OAI[OpenAI SDK Wrapper]
+  end
+
+  subgraph External["External"]
+    OpenAI[OpenAI GPT-4o Vision API]
+  end
+
+  subgraph Firebase["Firebase"]
+    RTDB[(Realtime DB)]
+    Secrets[(Functions Secret Manager)]
+  end
+
+  UI -- 사진, 4옵션 --> AIB
+  AIB -- POST --> API
+  API --> RL
+  RL --> RTDB
+  API --> OAI
+  OAI --> OpenAI
+  OpenAI --> OAI
+  OAI --> API
+  API --> AIB
+  AIB --> Cache
+  AIB --> UI
+  API -.읽기.-> Secrets
+```
+
+### 3.2 배포 아키텍처
+
+- **정적 리소스**: Firebase Hosting (기존)
+- **SSR / API Routes**: Firebase Cloud Functions (기존 `webframeworks` 실험 기능)
+- **API 키 보관**: Firebase Functions Secret Manager (`OPENAI_API_KEY`)
+- **레이트 리밋 스토리지**: 기존 Firebase Realtime Database (`omctDb` 확장)
+
+새로운 인프라 구성 요소는 없음. 기존 인프라 위에 API 라우트만 추가.
+
+---
+
+## 4. 상세 플로우
+
+### 4.1 시퀀스 다이어그램 (Happy Path, 하이브리드 라우팅)
+
+```mermaid
+sequenceDiagram
+  actor U as 유저
+  participant C as Client (BasicStage)
+  participant Cache as Recoil Cache
+  participant API as /api/ai-recommend
+  participant RL as Rate Limiter (RTDB)
+  participant Mini as GPT-4o-mini
+  participant Full as GPT-4o
+
+  U->>C: [AI 추천 받기] 클릭
+  C->>Cache: 이 문항에 캐시된 결과?
+  alt 캐시 있음
+    Cache-->>C: recommendation
+    C-->>U: 하이라이트 + 이유 표시
+  else 캐시 없음
+    C->>C: 이미지 리사이즈 (max 800px)
+    C->>API: POST { imageBase64, stageNum, options }
+    API->>RL: 사용 횟수 확인/증가
+    alt 한도 초과
+      RL-->>API: 429
+      API-->>C: { error: 'RATE_LIMITED' }
+      C-->>U: "오늘 추천 횟수를 모두 사용했어요"
+    else 통과
+      RL-->>API: OK
+      Note over API,Mini: 1차 시도 (저비용 경로)
+      API->>Mini: chat.completions.create(vision, JSON mode)
+      Mini-->>API: { recommendedType, reasoning, confidence }
+      alt confidence ≥ 0.7
+        API-->>C: 200 recommendation (source: 'mini')
+      else confidence < 0.7 (경계 케이스)
+        Note over API,Full: 2차 시도 (고정확도 경로)
+        API->>Full: chat.completions.create(vision, JSON mode)
+        Full-->>API: { recommendedType, reasoning, confidence }
+        API-->>C: 200 recommendation (source: 'full')
+      end
+      C->>Cache: 저장
+      C-->>U: 하이라이트 + 이유 표시
+    end
+  end
+```
+
+**하이브리드 라우팅 정책**
+- **1차: GPT‑4o‑mini** — 저비용/저지연 경로. 대부분의 명확한 케이스는 여기서 종결
+- **2차: GPT‑4o** — mini의 `confidence < 0.7` 일 때만 승격. 경계 케이스 정확도 확보
+- **임계값(0.7) 조정**: 실제 사용 데이터로 A/B 튜닝
+- **폴백 실패 시**: mini 응답 그대로 반환 (유저 경험 최소한 유지)
+
+### 4.2 데이터 흐름 (Data Flow)
+
+```mermaid
+flowchart LR
+  subgraph Input
+    IMG[유저 크롭 이미지<br/>base64 dataURL]
+    OPT[현재 문항의 4개 옵션<br/>type + hex + name]
+  end
+
+  subgraph ClientProcess["Client 전처리"]
+    RS[Canvas로 800×800<br/>리사이즈]
+    B64[base64 재인코딩]
+  end
+
+  subgraph Request
+    REQ["POST body:<br/>{ imageBase64, stageNum, options }"]
+  end
+
+  subgraph ServerProcess["Server 처리"]
+    VAL[스키마 검증]
+    RATE[레이트 리밋 체크]
+    PROMPT[프롬프트 조립]
+    CALL[OpenAI API 호출]
+    PARSE[JSON 파싱 & 검증]
+  end
+
+  subgraph Response
+    RES["{ recommendedType,<br/>reasoning, confidence }"]
+  end
+
+  subgraph ClientRender["Client 렌더링"]
+    HILITE[해당 옵션 하이라이트]
+    TIP[이유 툴팁 표시]
+    SAVE[Recoil 캐시 저장]
+  end
+
+  IMG --> RS
+  RS --> B64
+  OPT --> REQ
+  B64 --> REQ
+  REQ --> VAL
+  VAL --> RATE
+  RATE --> PROMPT
+  PROMPT --> CALL
+  CALL --> PARSE
+  PARSE --> RES
+  RES --> HILITE
+  RES --> TIP
+  RES --> SAVE
+```
+
+### 4.3 상태 다이어그램 (Client UI)
+
+암묵 동의 정책 채택으로 인해 별도 Consent 상태 없음. 개인정보처리방침에만 명시.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Loading: [AI 추천 받기] 클릭
+
+  Loading --> Success: API 성공
+  Loading --> Error: API 실패
+  Loading --> RateLimited: 429
+
+  Success --> Idle: 다음 문항 이동
+  Error --> Idle: 재시도 or 닫기
+  RateLimited --> Disabled
+  Disabled --> [*]
+
+  note right of Success
+    - 하이라이트 링
+    - 이유 툴팁
+    - Recoil 캐시 저장
+  end note
+```
+
+---
+
+## 5. 기술 스택
+
+| 영역 | 기술 | 비고 |
+| --- | --- | --- |
+| **AI 모델 (1차)** | OpenAI **GPT‑4o‑mini** (`gpt-4o-mini-2024-07-18`) | 비용/속도 유리, 대부분 케이스 처리 |
+| **AI 모델 (폴백)** | OpenAI **GPT‑4o** (`gpt-4o-2024-08-06`) | mini의 confidence < 0.7 시 승격 |
+| **SDK** | `openai` npm 패키지 (v4+) | 공식 |
+| **런타임** | Next.js API Route (Node.js) | Firebase Functions로 배포됨 (`webframeworks`) |
+| **비밀 관리** | Firebase Functions Secret Manager | `OPENAI_API_KEY` |
+| **레이트 리밋 스토리지** | Firebase Realtime Database (기존 `omctDb`) | 세션/IP 카운터 |
+| **클라이언트 상태** | Recoil (기존) | `aiRecommendCacheAtom`, `aiRecommendUsageAtom` |
+| **이미지 리사이즈** | 브라우저 Canvas API | 서버 트래픽 최소화 |
+| **국제화** | `next-i18next` (기존) | ko/en 문구 |
+
+### 5.1 신규 의존성
+```json
+{
+  "dependencies": {
+    "openai": "^4.60.0"
+  }
+}
+```
+
+### 5.2 대안 검토
+
+| 옵션 | 장점 | 단점 |
+| --- | --- | --- |
+| GPT‑4o‑mini + GPT‑4o 하이브리드 **(선택)** | 평균 비용/지연 최소화 + 경계 케이스 정확도 확보 | 구현 복잡도 소폭 상승, 임계값 튜닝 필요 |
+| GPT‑4o 단독 | 최고 정확도, 구현 단순 | 항상 최대 비용 발생 |
+| GPT‑4o‑mini 단독 | 최저 비용/최고 속도 | 경계 케이스 정확도 리스크 |
+| GPT‑4.1 | 최고 정확도 | 비용 높음, 속도 느림 |
+| 온디바이스 (TFJS 등) | 프라이버시 강점, 무료 | 정확도↓, 번들 커짐 |
+
+**결론**: **하이브리드 라우팅** 채택.
+- 1차 mini로 저비용 처리 → confidence ≥ 0.7 이면 그대로 반환
+- confidence < 0.7 시 GPT‑4o로 승격 → 정확도 확보
+- 실사용 데이터로 임계값 A/B 튜닝
+- 폴백률(2차 호출 비율) 모니터링 → 20% 이상이면 프롬프트/모델 재검토
+
+---
+
+## 6. API 설계
+
+### 6.1 엔드포인트
+```
+POST /api/ai-recommend
+```
+
+### 6.2 Request
+
+```ts
+type AiRecommendRequest = {
+  imageBase64: string;         // "data:image/jpeg;base64,..." 또는 순수 base64
+  stageNum: number;            // 0-8, 현재 문항 번호 (캐시/디버깅용)
+  options: Array<{
+    type: ColorType;           // 'springwarm' | 'summercool' | ...
+    color: string;             // '#ff6448' 같은 hex
+    name: string;              // 사람이 읽을 수 있는 색 이름 (선택, 디버깅용)
+  }>;
+  sessionId: string;           // 클라이언트 발급 UUID, 레이트 리밋용
+};
+```
+
+### 6.3 Response
+
+**200 성공**
+```ts
+type AiRecommendResponse = {
+  recommendedType: ColorType;
+  reasoning: string;           // 1-2 문장의 한국어(또는 요청 locale)
+  confidence: number;          // 0.0 - 1.0 (최종 반환 모델의 confidence)
+  usageRemaining: number;      // 이 세션에서 남은 요청 수
+  source: 'mini' | 'full';     // 어떤 모델이 최종 응답했는지 (관찰용)
+};
+```
+
+**4xx / 5xx 에러**
+```ts
+type AiRecommendError = {
+  error:
+    | 'INVALID_INPUT'         // 400
+    | 'RATE_LIMITED'          // 429
+    | 'AI_UNAVAILABLE'        // 502 (OpenAI 장애)
+    | 'INTERNAL_ERROR';       // 500
+  message: string;
+  retryAfterSeconds?: number;  // 429일 때
+};
+```
+
+### 6.4 프롬프트 (초안)
+
+**System Message**
+```
+You are a professional Korean personal color consultant.
+
+Given a user's face photo and 4 color candidates, choose which single color
+best suits the person based on their skin undertone, eye color, and hair color.
+
+You MUST respond with a JSON object matching this schema exactly:
+{
+  "recommendedType": string,   // one of the provided option types, verbatim
+  "reasoning": string,          // 1-2 sentences in Korean
+  "confidence": number          // 0.0 - 1.0
+}
+
+Do NOT include any text outside the JSON object.
+```
+
+**User Message**
+```
+[image_url or base64 image]
+
+옵션:
+[
+  { "type": "springwarm", "color": "#ff6448", "name": "봄 웜" },
+  { "type": "summercool", "color": "#1cace1", "name": "여름 쿨" },
+  ...
+]
+
+가장 어울리는 하나를 골라주세요.
+```
+
+### 6.5 OpenAI SDK 호출 예시 (하이브리드 라우팅)
+
+```ts
+const CONFIDENCE_THRESHOLD = 0.7;
+
+async function callModel(model: string, dataUri: string, options: Option[]) {
+  const completion = await openai.chat.completions.create({
+    model,
+    response_format: { type: 'json_object' },
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      {
+        role: 'user',
+        content: [
+          { type: 'image_url', image_url: { url: dataUri, detail: 'low' } },
+          { type: 'text', text: buildOptionsText(options) },
+        ],
+      },
+    ],
+    max_tokens: 200,
+    temperature: 0.3,
+  });
+  return parseAndValidate(completion.choices[0].message.content);
+}
+
+async function getRecommendation(dataUri: string, options: Option[]) {
+  // 1차: mini
+  const miniResult = await callModel('gpt-4o-mini-2024-07-18', dataUri, options);
+
+  if (miniResult.confidence >= CONFIDENCE_THRESHOLD) {
+    return { ...miniResult, source: 'mini' as const };
+  }
+
+  // 2차: full (경계 케이스만 승격)
+  try {
+    const fullResult = await callModel('gpt-4o-2024-08-06', dataUri, options);
+    return { ...fullResult, source: 'full' as const };
+  } catch (err) {
+    // 폴백 실패 시 mini 응답 그대로 반환 (유저 경험 최소한 유지)
+    console.error('Full model fallback failed', err);
+    return { ...miniResult, source: 'mini' as const };
+  }
+}
+```
+
+**공통 옵션**
+- `detail: 'low'` → 토큰 절감 (얼굴 형태만 인식하면 충분)
+- `temperature: 0.3` → 재현성 확보
+- `response_format: { type: 'json_object' }` → JSON 강제
+
+**관찰 지표 (Sentry/Firebase Analytics로 기록)**
+- 총 요청 중 폴백 발생률
+- mini/full 각각의 평균 지연
+- confidence 히스토그램 (임계값 튜닝용)
+
+---
+
+## 7. UI/UX 설계
+
+### 7.1 배치
+
+BasicStage의 4 컬러 그리드 하단, 진행 인디케이터 위에 배치.
+
+```
+┌─────────────────────┐
+│    문항 텍스트      │
+├──────┬──────┬───────┤
+│  🎨   │  🎨   │  🎨   │  ← 4개 컬러 옵션
+├──────┼──────┼───────┤
+│  🎨   │       │       │
+├──────┴──────┴───────┤
+│  ✨ AI 추천 받기     │  ← 새 요소 (텍스트 링크 스타일)
+├─────────────────────┤
+│ ● ● ● ○ ○ ○ ○ ○ ○  │  ← 진행 인디케이터
+└─────────────────────┘
+```
+
+### 7.2 상태별 UI
+
+| 상태 | 표시 |
+| --- | --- |
+| **Idle** | `✨ AI 추천 받기` (회색 텍스트 링크) |
+| **Loading** | 스피너 + "AI가 분석 중..." (2‑7초) |
+| **Success** | 추천 옵션에 반짝이는 링 애니메이션 + 하단 툴팁 "AI 추천: [이유]" |
+| **Error** | 스낵바 "지금은 추천을 받을 수 없어요" + 재시도 링크 |
+| **RateLimited** | 버튼 비활성화 + "오늘 사용 가능 횟수를 모두 사용했어요" |
+
+> 별도 동의 모달 없음. 개인정보처리방침에 명시된 내용에 대한 암묵 동의로 처리.
+
+### 7.3 하이라이트 애니메이션
+
+- 선택된 옵션 컬러 원 주위에 CSS `box-shadow` + `keyframes` 로 부드러운 pulse
+- 접근성: `prefers-reduced-motion` 존중해 애니메이션 off
+
+### 7.4 다국어
+
+- 신규 번역 키 (ko/en 동시 첫 릴리즈):
+  - `aiRecommend.button`
+  - `aiRecommend.loading`
+  - `aiRecommend.error.generic`
+  - `aiRecommend.error.rateLimited`
+  - `aiRecommend.result.prefix`
+
+> 동의 모달 미채택. Consent 관련 키 없음.
+
+---
+
+## 8. 프라이버시 & 준수사항
+
+### 8.1 데이터 처리 원칙
+- **최소 수집**: 얼굴 사진만 전송, 이름/이메일 등 PII 미포함
+- **즉시 폐기**: 서버 응답 후 이미지 메모리에서 즉시 폐기, 파일/로그 저장 금지
+- **로그 정책**: 이미지·base64 절대 로깅 금지. 메타데이터(요청 timestamp, session hash, latency, tokens)만 기록
+- **저장 없음**: RTDB에는 카운터만 저장, 이미지·응답 텍스트 미저장
+
+### 8.2 OpenAI 데이터 정책
+- OpenAI API는 기본적으로 학습에 사용되지 않음 (2023년 3월 이후)
+- 30일 abuse monitoring 로그는 존재. Enterprise 계약 시 Zero Data Retention 옵션 가능
+- 개인정보처리방침에 "얼굴 사진이 OpenAI로 전송되어 분석에 사용됩니다"를 명시할 것
+
+### 8.3 동의 절차 (암묵 동의)
+- 별도 모달 없음 — UX 매끄러움 우선
+- **개인정보처리방침에 명시**:
+  - "AI 색상 추천 기능 사용 시 사용자가 업로드한 얼굴 이미지가 OpenAI(gpt‑4o‑mini / gpt‑4o) API로 전송됩니다"
+  - "이미지는 서버 측에서 응답 후 즉시 폐기되며, 저장되지 않습니다"
+  - "OpenAI는 API 데이터를 학습에 사용하지 않으며, abuse monitoring 목적의 30일 로그가 존재할 수 있습니다"
+- AI 추천 버튼 근처에 개인정보처리방침 링크 노출 (`i` 아이콘 등 subtle 표시) — 유저가 원할 때 언제든 확인 가능
+- 향후 GDPR/EU 트래픽 대응 시 명시적 동의 모달 재도입 검토
+
+**리스크 인식**
+- 암묵 동의는 UX 편의성 우선. 대한민국 개인정보보호법 관점에서는 처리방침 명시로 충분하나, EU/UK 유저 대응에서는 GDPR 명시적 동의 요구될 수 있음
+- 글로벌 확장 시 CMP 도입 검토 필요 (AdSense 승인 프로세스에서도 이미 CMP 세팅 완료됨 — 재활용 가능)
+
+---
+
+## 9. 비용 & 성능 견적
+
+### 9.1 토큰당 비용 (GPT‑4o 기준, 2026-07 기준)
+- Input: $2.50 / 1M tokens
+- Output: $10.00 / 1M tokens
+- Vision (`low` detail): 이미지당 ~85 tokens
+
+### 9.1.b GPT‑4o‑mini 가격
+- Input: **$0.15** / 1M tokens
+- Output: **$0.60** / 1M tokens
+- 이미지 토큰 계산은 4o와 동일
+
+### 9.2 요청당 추정
+| 항목 | 토큰 |
+| --- | --- |
+| System prompt | ~120 |
+| Image (low detail) | ~85 |
+| Options JSON | ~150 |
+| Output | ~100 |
+| **합계** | ~455 tokens |
+
+**단일 호출당 비용**
+- mini 단독: **~$0.0001** (약 0.15원)
+- full 단독: **~$0.0015** (약 2원)
+
+**하이브리드 평균 (폴백률 20% 가정)**
+- 평균 비용: `0.8 × $0.0001 + 0.2 × ($0.0001 + $0.0015)` = **~$0.0004** (약 0.6원)
+- 4o 단독 대비 **약 73% 절감**, mini 단독 대비 4배 증가 (그러나 정확도 확보)
+
+### 9.3 월간 예산 시나리오 (하이브리드 + 관대 레이트 리밋 기준)
+
+**설정된 알람 임계값**: **$30/월** (기대 시나리오 대비 약 2.3배 여유)
+
+**레이트 리밋**: 세션당 9회 / IP 일일 30회 → 상한 시나리오의 세션당 요청 가정 상향
+
+| 시나리오 | DAU | AI 사용률 | 세션당 요청 (평균) | 월 요청 | 월 비용 (하이브리드) | 알람 상태 | 참고: 4o 단독 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 보수적 | 500 | 15% | 1.5 | ~3,400 | **~$1.5** | 🟢 안전 (5%) | ~$5 |
+| 기대 | 2,000 | 25% | 2.5 | ~37,500 | **~$16** | 🟢 안전 (53%) | ~$56 |
+| 상한 (관대 리밋 소진) | 5,000 | 40% | 6.0 | ~360,000 | **~$160** | 🔴 초과 (533%) | ~$540 |
+
+- 폴백률 20%는 초기 가정. 실 데이터로 재보정 필요.
+- 관대 레이트 리밋(세션당 9회) 채택으로 인해 **상한 시나리오의 위험이 이전보다 커짐** (평균 요청 3 → 6으로 상향).
+- **대응 방안**:
+  1. 알람 트리거 시 즉시 `NEXT_PUBLIC_ENABLE_AI_RECOMMEND=false` 로 재배포 → 기능 OFF
+  2. 또는 문서 Section 5의 `CONFIDENCE_THRESHOLD` 하향 조정으로 폴백률 감소 (예: 0.7 → 0.5)
+  3. 또는 레이트 리밋 축소 (세션당 9 → 3)
+
+### 9.4 응답 시간
+
+| 시나리오 | 서버 지연 (p50 → p95) | 총 사용자 체감 |
+| --- | --- | --- |
+| mini만으로 종결 (80%) | 1.5 → 3초 | **2‑3.5초** |
+| mini → 4o 폴백 (20%) | 3.5 → 7초 | **4‑7.5초** |
+| 평균 (0.8×mini + 0.2×hybrid) | ~2초 | **~2.5‑4.5초** |
+
+- 클라이언트 리사이즈: <500ms
+- 로딩 UI 필수 (폴백 시 최대 7초 대기 가능성)
+
+---
+
+## 10. 구현 마일스톤
+
+### Phase 0 — 검증 (0.5일)
+- 로컬 스크립트로 OpenAI API에 이미지 3‑5장 수동 요청
+- 프롬프트 정확도 튜닝
+- 응답 JSON 파싱 안정성 확인
+
+### Phase 1 — 백엔드 (1‑2일)
+- [ ] `openai` 패키지 설치
+- [ ] `pages/api/ai-recommend.ts` 라우트 구현
+- [ ] Zod 스키마로 요청/응답 검증
+- [ ] **하이브리드 라우팅 로직** (`getRecommendation`: mini 호출 → confidence 판정 → 필요 시 full 폴백)
+- [ ] `CONFIDENCE_THRESHOLD` 상수 및 관련 튜닝 훅
+- [ ] Rate limiter (`omctDb` 확장, 세션/IP 카운터)
+- [ ] `OPENAI_API_KEY` Secret 등록 (로컬 `.env.local`, Firebase Functions Secret)
+- [ ] 관찰 로깅: `source`, `confidence`, `latency`, `fallbackTriggered` 를 Sentry breadcrumb에 남김
+- [ ] 단위 테스트 (프롬프트 조립, 파싱, 폴백 트리거, 폴백 실패 처리)
+
+### Phase 2 — 프론트엔드 (1‑2일)
+- [ ] Recoil atoms: `aiRecommendCacheAtom`, `aiRecommendUsageAtom`
+- [ ] `useAiRecommend` 훅 (요청, 캐시, 에러 처리)
+- [ ] `AiRecommendButton` 컴포넌트 (상태별 UI)
+- [ ] BasicStage 통합 (9문항 모두)
+- [ ] 하이라이트 애니메이션 (styled‑components)
+- [ ] ko + en 번역 키 동시 추가
+- [ ] 개인정보처리방침 링크 노출 (버튼 근처)
+
+### Phase 3 — 통합 & 릴리즈 (1일)
+- [ ] Feature flag: **환경변수** `NEXT_PUBLIC_ENABLE_AI_RECOMMEND=true/false` (초기 off로 배포 → 준비 완료 시 on)
+- [ ] Sentry 이벤트 추적 (요청 수, 에러율, 지연)
+- [ ] 스테이징 배포 및 QA (사진 다양성 테스트, ko/en 스위치 확인)
+- [ ] **개인정보처리방침 문구 업데이트 (담당: 수야)** — Section 8.3 문구 기반
+- [ ] OpenAI 대시보드에 $30/월 예산 알람 세팅
+- [ ] 프로덕션 롤아웃 (환경변수 on 배포)
+
+### Phase 4 — 관찰 & 조정 (지속)
+- 실 사용량 vs 예산 모니터링
+- **폴백률 대시보드**: 폴백률이 30% 초과 시 프롬프트 재검토 또는 mini 모델 변경 검토
+- **confidence 히스토그램**: 실제 분포 확인 후 임계값 0.7 재조정 (예: 0.6 또는 0.75)
+- 정확도 피드백 수집 (선택적 유저 설문)
+- mini vs full 결과 정성 비교 (샘플링)
+
+**총 소요**: 3‑5일 (1인 기준, Phase 0‑3)
+
+---
+
+## 11. 리스크 및 대응
+
+| 리스크 | 심각도 | 대응 |
+| --- | --- | --- |
+| OpenAI API 장애 | 중 | Graceful fallback: 스낵바로 안내, 진단은 계속 진행 |
+| 응답이 non‑JSON | 중 | JSON mode + 파싱 실패 시 재시도 1회, 실패 시 에러 |
+| 비용 폭발 | 상 | 레이트 리밋 + 세션 캐시 + 월 예산 알람 (OpenAI 대시보드) |
+| 어뷰징 (봇 트래픽) | 상 | IP당 일일 제한 + Cloudflare Turnstile 등 CAPTCHA (필요시 추후) |
+| 얼굴이 없는 이미지 업로드 | 중 | OpenAI 프롬프트에 "얼굴이 없으면 recommendedType='NONE' 반환" 지시 후 클라이언트에서 에러 처리 |
+| 유저가 AI만 믿고 무성의 클릭 | 저 | 추천 문구를 subtle하게, "당신의 판단을 참고용으로 도와드립니다" |
+| 프라이버시 이슈 | 상 | 명시적 동의, 로깅 금지, 개인정보처리방침 업데이트 |
+| 다양한 인종/피부톤에서 편향 | 중 | Phase 0에서 다양한 샘플로 검증, 편향 발견 시 프롬프트 튜닝 |
+
+---
+
+## 12. 확장 여지
+
+### 향후 고려 가능한 개선
+- **최종 결과 페이지**: "AI가 본 당신" 코멘트 섹션
+- **선택 vs AI 통계**: 유저 선택과 AI 추천 일치율 표시 (동의 기반 익명 집계)
+- **온디바이스 사전 필터**: 얼굴 검출 후에만 API 호출 (비용 절감)
+- **다중 AI 앙상블**: 여러 모델 결과 통합 (정확도 향상)
+- **개인화 프롬프트**: 이전 선택 이력을 프롬프트에 반영
+- **음성 추천**: TTS로 접근성 향상
+
+---
+
+## 13. 미결 사항 (Open Questions)
+
+모든 결정 확정 (2026-07-02):
+
+1. ✅ **모델 라우팅**: 하이브리드 (mini 1차 + full 폴백, `confidence < 0.7` 시 승격)
+2. ✅ **하이브리드 임계값**: `CONFIDENCE_THRESHOLD = 0.7` — 실사용 데이터로 재조정
+3. ✅ **레이트 리밋 (관대 프로파일)**:
+   - 세션당 **9회** (모든 문항에서 가능)
+   - IP당 일일 **30회**
+   - ⚠ 상한 시나리오 비용 리스크 → Section 9.3 참조
+4. ✅ **월 예산 알람**: **$30/월** (OpenAI 대시보드). 초과 시 알람 → feature flag OFF
+5. ✅ **첫 릴리즈 범위**:
+   - **하이라이트 + 이유 텍스트** 함께 노출
+   - **9문항 모두**에서 AI 추천 버튼 노출
+6. ✅ **동의 방식**: **암묵 동의** — 별도 동의 모달 없이 **개인정보처리방침에 명시**. UX 매끄러움 우선
+7. ✅ **다국어**: **ko + en 동시** 첫 릴리즈부터
+8. ✅ **Feature flag 방식**: **환경변수** (`NEXT_PUBLIC_ENABLE_AI_RECOMMEND`). 즉시 on/off 필요 시 재배포 감수
+9. ✅ **폴백 실패 정책**: **mini 응답 반환** (유저에게 최소한의 답변 제공, `source: 'mini'`로 관찰 로그 기록)
+10. ✅ **개인정보처리방침 담당**: **본인(수야)** 직접 작성 및 배포
+
+---
+
+## 14. 관련 파일 & 참조
+
+### 신규 추가 예정 파일
+- `src/pages/api/ai-recommend.ts` — API 라우트
+- `src/hooks/useAiRecommend.ts` — 클라이언트 훅
+- `src/components/AiRecommend/AiRecommendButton.tsx`
+- `src/recoil/aiRecommend.ts` — Recoil atoms
+- `src/utils/openaiClient.ts` — SDK wrapper (하이브리드 라우팅 포함)
+- `src/utils/imageResize.ts` — 클라이언트 리사이즈
+- `public/locales/{ko,en}/common.json` — 번역 키 추가 (ko/en 동시)
+
+> `AiConsentModal` 컴포넌트 미채택 (암묵 동의 정책).
+
+### 수정 예정 파일
+- `src/pages/choice-color/BasicStage/index.tsx` — 버튼 통합
+- `src/utils/omctDb.ts` — 레이트 리밋 카운터 추가
+- `.env.local` / `.env.example` — 환경변수 문서화
+- `.github/workflows/firebase-hosting-merge.yml` — Secret 주입 추가
+
+### 참조
+- 기존 도메인 문서: [personal-color-algorithm.md](./personal-color-algorithm.md)
+- OpenAI Vision API 공식: https://platform.openai.com/docs/guides/vision
+- Firebase Functions Secret Manager: https://firebase.google.com/docs/functions/config-env#secret-manager

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const { withSentryConfig } = require('@sentry/nextjs');
 const { i18n } = require('./next-i18next.config.js');
 
 const nextConfig = {
-  pageExtensions: ['page.tsx'],
+  pageExtensions: ['page.tsx', 'page.ts'],
   reactStrictMode: true,
   compiler: {
     styledComponents: true,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "prepare": "husky install",
     "lint": "next lint",
     "lint-staged": "lint-staged",
-    "lint-fix": "eslint '**/*.{tsx,ts}' --ext .ts,.tsx --fix"
+    "lint-fix": "eslint '**/*.{tsx,ts}' --ext .ts,.tsx --fix",
+    "ai-recommend:check": "tsx --env-file=.env.local scripts/ai-recommend-check.ts"
   },
   "lint-staged": {
     "**/*.{tsx,ts,jsx,js}": [
@@ -33,12 +34,14 @@
     "css-line-break": "^2.1.0",
     "eslint-config-prettier": "^8.6.0",
     "firebase": "^9.17.1",
+    "firebase-admin": "^14.1.0",
     "i18next": "^23.12.2",
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-http-backend": "^2.5.2",
     "js-md5": "^0.8.3",
     "next": "^14.2.4",
     "next-i18next": "^15.3.1",
+    "openai": "^4.60.0",
     "react": "^18.2.0",
     "react-avatar-editor": "^13.0.0",
     "react-dom": "^18.2.0",
@@ -49,7 +52,8 @@
     "styled-components": "^5.3.6",
     "stylelint-config-prettier": "^9.0.5",
     "text-segmentation": "^1.0.3",
-    "ua-parser-js": "^2.0.0-alpha.2"
+    "ua-parser-js": "^2.0.0-alpha.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^13.5.4",
@@ -65,6 +69,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.2",
+    "tsx": "^4.22.4",
     "typescript": "^5.7.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -232,5 +232,28 @@
   "myTestUrl": "Your Personal Color Test Link",
   "shareMyTestUrl": "Share My Test",
   "onboarding1": "Choose a card that looks best on you\namong the four cards.",
-  "onboarding-confirm": "Confirm"
+  "onboarding-confirm": "Confirm",
+  "aiRecommend": {
+    "button": "✨ Get AI recommendation",
+    "loading": "AI is analyzing...",
+    "privacyLink": "About AI usage",
+    "result": {
+      "prefix": "AI's pick of these 4"
+    },
+    "error": {
+      "generic": "We can't get a recommendation right now",
+      "rateLimited": "You've used all your recommendations for today",
+      "noFace": "We couldn't see the face clearly",
+      "retry": "Try again"
+    },
+    "consent": {
+      "title": "Please agree to use AI color recommendations.",
+      "purpose": "Purpose: providing AI-based color recommendations",
+      "data": "Data sent: a downscaled face image (max 800×800)",
+      "destination": "Sent to: OpenAI (gpt-4o-mini / gpt-4o) API",
+      "retention": "Retention: discarded immediately after the response, not stored",
+      "openaiPolicy": "OpenAI does not use API data for training, though a 30-day abuse-monitoring log may exist.",
+      "guide": "You can decline. If you decline, AI recommendation will be disabled."
+    }
+  }
 }

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -232,5 +232,28 @@
   "myTestUrl": "내 퍼스널 컬러 진단 링크",
   "shareMyTestUrl": "내 진단 공유하기",
   "onboarding1": "4개의 카드 중 얼굴과 잘 어울리는\n카드를 선택해주세요",
-  "onboarding-confirm": "확인"
+  "onboarding-confirm": "확인",
+  "aiRecommend": {
+    "button": "✨ AI 추천 받기",
+    "loading": "AI가 분석 중...",
+    "privacyLink": "AI 이용 안내",
+    "result": {
+      "prefix": "이 4가지 중 AI 픽"
+    },
+    "error": {
+      "generic": "지금은 추천을 받을 수 없어요",
+      "rateLimited": "오늘 사용 가능 횟수를 모두 사용했어요",
+      "noFace": "얼굴이 잘 보이지 않아요",
+      "retry": "다시 시도"
+    },
+    "consent": {
+      "title": "AI 색상 추천 이용에 동의해 주세요.",
+      "purpose": "이용 목적: AI 기반 컬러 추천 제공",
+      "data": "전송 항목: 축소된 얼굴 이미지 (최대 800×800)",
+      "destination": "전송 대상: OpenAI (gpt-4o-mini / gpt-4o) API",
+      "retention": "보유 및 이용 기간: 서버 응답 후 즉시 폐기, 저장하지 않음",
+      "openaiPolicy": "OpenAI는 API 데이터를 학습에 사용하지 않으며, abuse monitoring 목적의 30일 로그가 존재할 수 있어요.",
+      "guide": "동의를 거부할 수 있으며, 거부 시 AI 추천 기능 이용이 제한됩니다."
+    }
+  }
 }

--- a/scripts/ai-recommend-check.ts
+++ b/scripts/ai-recommend-check.ts
@@ -1,0 +1,181 @@
+/**
+ * Phase 0 검증 스크립트 — OpenAI 이미지 분석 프롬프트 정확도/JSON 안정성 확인용.
+ *
+ * 사용법:
+ *   yarn ai-recommend:check <image-path>
+ *   yarn ai-recommend:check <image-path> --options ./sample-options.json
+ *   yarn ai-recommend:check <image-path> --only mini
+ *   yarn ai-recommend:check <image-path> --only full
+ *
+ * 요구사항:
+ *   - .env.local 에 OPENAI_API_KEY 설정
+ *   - image-path 는 로컬 JPEG/PNG 파일 (풀 얼굴 사진)
+ *
+ * 출력:
+ *   - mini / full 각각의 응답 JSON, latency, tokens
+ *   - confidence 비교 (임계값 0.7 튜닝 참고)
+ *
+ * 프롬프트는 src/utils/aiRecommend/prompt.ts 에서 공유되며 API 라우트와
+ * 동일 문구를 사용한다.
+ */
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+
+import OpenAI from 'openai';
+
+import { SYSTEM_PROMPT, buildUserText } from '../src/utils/aiRecommend/prompt';
+import type { AiRecommendOption } from '../src/utils/aiRecommend/schema';
+
+const DEFAULT_OPTIONS: AiRecommendOption[] = [
+  { type: 'springwarm', color: '#ff6448', name: '봄 웜 (레드오렌지)', season: 'spring', tone: 'warm' },
+  { type: 'summercool', color: '#1cace1', name: '여름 쿨 (스카이블루)', season: 'summer', tone: 'cool' },
+  { type: 'autumndeep', color: '#7d5544', name: '가을 딥 (다크브라운)', season: 'autumn', tone: 'deep' },
+  { type: 'winterbright', color: '#f91893', name: '겨울 브라이트 (핫핑크)', season: 'winter', tone: 'bright' },
+];
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+};
+
+async function toDataUri(imagePath: string): Promise<string> {
+  const buf = await readFile(imagePath);
+  const ext = extname(imagePath).toLowerCase();
+  const mime = MIME_BY_EXT[ext];
+  if (!mime) {
+    throw new Error(`Unsupported image extension: ${ext}`);
+  }
+  return `data:${mime};base64,${buf.toString('base64')}`;
+}
+
+type CallResult = {
+  model: string;
+  latencyMs: number;
+  usage?: OpenAI.CompletionUsage;
+  parsed: {
+    recommendedType: string;
+    reasoning: string;
+    confidence: number;
+  };
+  raw: string;
+};
+
+async function callModel(
+  openai: OpenAI,
+  model: string,
+  dataUri: string,
+  options: AiRecommendOption[],
+): Promise<CallResult> {
+  const started = Date.now();
+  const completion = await openai.chat.completions.create({
+    model,
+    response_format: { type: 'json_object' },
+    max_tokens: 200,
+    temperature: 0.3,
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      {
+        role: 'user',
+        content: [
+          { type: 'image_url', image_url: { url: dataUri, detail: 'low' } },
+          { type: 'text', text: buildUserText(options) },
+        ],
+      },
+    ],
+  });
+  const latencyMs = Date.now() - started;
+  const raw = completion.choices[0]?.message?.content ?? '';
+  const parsed = JSON.parse(raw);
+  return {
+    model,
+    latencyMs,
+    usage: completion.usage,
+    parsed,
+    raw,
+  };
+}
+
+function printResult(result: CallResult) {
+  const { model, latencyMs, usage, parsed } = result;
+  console.log(`\n=== ${model} ===`);
+  console.log(`latency: ${latencyMs}ms`);
+  if (usage) {
+    console.log(
+      `tokens: prompt=${usage.prompt_tokens} completion=${usage.completion_tokens} total=${usage.total_tokens}`,
+    );
+  }
+  console.log(`recommendedType: ${parsed.recommendedType}`);
+  console.log(`confidence:      ${parsed.confidence}`);
+  console.log(`reasoning:       ${parsed.reasoning}`);
+}
+
+function parseCliArgs(argv: string[]) {
+  const [, , ...rest] = argv;
+  if (rest.length === 0) {
+    throw new Error(
+      'Usage: yarn ai-recommend:check <image-path> [--options <json-file>] [--only mini|full]',
+    );
+  }
+  const imagePath = rest[0];
+  let optionsPath: string | undefined;
+  let only: 'mini' | 'full' | undefined;
+  for (let i = 1; i < rest.length; i += 1) {
+    const arg = rest[i];
+    if (arg === '--options') {
+      optionsPath = rest[i + 1];
+      i += 1;
+    } else if (arg === '--only') {
+      const value = rest[i + 1];
+      if (value !== 'mini' && value !== 'full') {
+        throw new Error('--only must be "mini" or "full"');
+      }
+      only = value;
+      i += 1;
+    }
+  }
+  return { imagePath, optionsPath, only };
+}
+
+async function main() {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'OPENAI_API_KEY is not set. Run with: yarn ai-recommend:check <image-path>\n' +
+        '(package.json script uses --env-file=.env.local)',
+    );
+  }
+
+  const { imagePath, optionsPath, only } = parseCliArgs(process.argv);
+  const dataUri = await toDataUri(imagePath);
+  const options: AiRecommendOption[] = optionsPath
+    ? JSON.parse(await readFile(optionsPath, 'utf-8'))
+    : DEFAULT_OPTIONS;
+
+  const openai = new OpenAI({ apiKey });
+
+  const targets: Array<'mini' | 'full'> = only ? [only] : ['mini', 'full'];
+  const modelIds: Record<'mini' | 'full', string> = {
+    mini: 'gpt-4o-mini-2024-07-18',
+    full: 'gpt-4o-2024-08-06',
+  };
+
+  console.log(`image:   ${imagePath}`);
+  console.log(`options: ${options.map((o) => o.type).join(', ')}`);
+
+  for (const key of targets) {
+    try {
+      const result = await callModel(openai, modelIds[key], dataUri, options);
+      printResult(result);
+    } catch (err) {
+      console.error(`\n=== ${modelIds[key]} FAILED ===`);
+      console.error(err);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/AiRecommend/AiConsentModal.tsx
+++ b/src/components/AiRecommend/AiConsentModal.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from 'next-i18next';
+
+import Snackbar from '@Components/Snackbar';
+
+import * as S from './consentStyle';
+
+interface AiConsentModalProps {
+  isOpen: boolean;
+  onAgree: () => void;
+  onDisagree: () => void;
+}
+
+function AiConsentModal({ isOpen, onAgree, onDisagree }: AiConsentModalProps) {
+  const { t } = useTranslation('common');
+
+  return (
+    <Snackbar isOpen={isOpen} onClose={onDisagree}>
+      <S.ConsentWrapper>
+        <h1>{t('aiRecommend.consent.title')}</h1>
+        <ul>
+          <li>{t('aiRecommend.consent.purpose')}</li>
+          <li>{t('aiRecommend.consent.data')}</li>
+          <li>{t('aiRecommend.consent.destination')}</li>
+          <li>{t('aiRecommend.consent.retention')}</li>
+        </ul>
+        <p>{t('aiRecommend.consent.openaiPolicy')}</p>
+        <p>{t('aiRecommend.consent.guide')}</p>
+      </S.ConsentWrapper>
+      <S.ButtonRow>
+        <S.SecondaryButton type="button" onClick={onDisagree}>
+          {t('disagree')}
+        </S.SecondaryButton>
+        <S.PrimaryButton type="button" onClick={onAgree}>
+          {t('agree')}
+        </S.PrimaryButton>
+      </S.ButtonRow>
+    </Snackbar>
+  );
+}
+
+export default AiConsentModal;

--- a/src/components/AiRecommend/consentStyle.ts
+++ b/src/components/AiRecommend/consentStyle.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+import { Button, BorderedButton, flexCustom } from '@Styles/theme';
+
+export const ConsentWrapper = styled.div`
+  ${flexCustom('column', 'flex-start', 'center')}
+  row-gap: 1rem;
+  padding-bottom: 1rem;
+
+  & h1 {
+    font-size: ${({ theme }) => theme.font.size.lg};
+    font-family: inherit;
+    font-weight: 600;
+  }
+
+  & ul {
+    list-style-type: disc;
+    color: ${({ theme }) => theme.gray[600]};
+
+    & li {
+      margin-left: 1.5rem;
+      font-size: ${({ theme }) => theme.font.size.sm};
+    }
+  }
+
+  & p {
+    font-size: ${({ theme }) => theme.font.size.xs};
+    color: ${({ theme }) => theme.gray[400]};
+  }
+`;
+
+export const ButtonRow = styled.div`
+  ${flexCustom('row', 'center', 'center')}
+  column-gap: 0.5rem;
+`;
+
+export const PrimaryButton = styled(Button)`
+  flex-basis: 60%;
+`;
+
+export const SecondaryButton = styled(BorderedButton)`
+  flex-basis: 40%;
+`;

--- a/src/components/AiRecommend/index.tsx
+++ b/src/components/AiRecommend/index.tsx
@@ -1,0 +1,131 @@
+import { useTranslation } from 'next-i18next';
+
+import { useAiRecommend } from '@Hooks/useAiRecommend';
+
+import AiConsentModal from './AiConsentModal';
+import * as S from './style';
+
+export type AiRecommendChoice = {
+  type: ColorType;
+  color: string;
+  name?: string;
+  season: ColorSeason;
+  tone: ColorTone;
+};
+
+interface AiRecommendButtonProps {
+  stageNum: number;
+  userImg: string;
+  options: AiRecommendChoice[];
+  privacyHref?: string;
+}
+
+function AiRecommendButton({
+  stageNum,
+  userImg,
+  options,
+  privacyHref,
+}: AiRecommendButtonProps) {
+  const { t } = useTranslation('common');
+  const {
+    enabled,
+    status,
+    error,
+    cached,
+    request,
+    clearError,
+    isConsentModalOpen,
+    agreeConsent,
+    denyConsent,
+  } = useAiRecommend(stageNum);
+
+  if (!enabled) return null;
+
+  const handleRequest = () => {
+    void request(
+      userImg,
+      options.map((o) => ({
+        type: o.type,
+        color: o.color,
+        name: o.name,
+        season: o.season,
+        tone: o.tone,
+      })),
+    );
+  };
+
+  const renderContent = () => {
+    if (status === 'loading') {
+      return (
+        <S.Button type="button" isDisabled disabled>
+          <S.Spinner aria-hidden />
+          {t('aiRecommend.loading')}
+        </S.Button>
+      );
+    }
+
+    if (status === 'success' && cached) {
+      return (
+        <S.ResultBanner role="status">
+          <S.ResultLabel>{t('aiRecommend.result.prefix')}</S.ResultLabel>
+          <span>{cached.reasoning}</span>
+        </S.ResultBanner>
+      );
+    }
+
+    if (status === 'rateLimited') {
+      return (
+        <S.Button type="button" isDisabled disabled>
+          {t('aiRecommend.error.rateLimited')}
+        </S.Button>
+      );
+    }
+
+    if (status === 'error' && error) {
+      const message =
+        error.code === 'NO_FACE_DETECTED'
+          ? t('aiRecommend.error.noFace')
+          : t('aiRecommend.error.generic');
+      return (
+        <div>
+          <S.ErrorText>{message}</S.ErrorText>
+          <S.RetryLink
+            type="button"
+            onClick={() => {
+              clearError();
+              handleRequest();
+            }}
+          >
+            {t('aiRecommend.error.retry')}
+          </S.RetryLink>
+        </div>
+      );
+    }
+
+    return (
+      <S.Button type="button" onClick={handleRequest}>
+        {t('aiRecommend.button')}
+      </S.Button>
+    );
+  };
+
+  return (
+    <S.Wrapper>
+      {renderContent()}
+      {privacyHref ? (
+        <S.PrivacyLink href={privacyHref} target="_blank" rel="noreferrer">
+          {t('aiRecommend.privacyLink')}
+        </S.PrivacyLink>
+      ) : null}
+      <AiConsentModal
+        isOpen={isConsentModalOpen}
+        onAgree={() => {
+          void agreeConsent();
+        }}
+        onDisagree={denyConsent}
+      />
+    </S.Wrapper>
+  );
+}
+
+export default AiRecommendButton;

--- a/src/components/AiRecommend/style.ts
+++ b/src/components/AiRecommend/style.ts
@@ -1,0 +1,94 @@
+import styled, { css, keyframes } from 'styled-components';
+
+import { flexCustom } from '@Styles/theme';
+
+const spin = keyframes`
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+`;
+
+export const Wrapper = styled.div`
+  ${flexCustom('column', 'center', 'center')}
+  row-gap: 0.5rem;
+  padding: 0.75rem 0;
+`;
+
+export const Button = styled.button<{ isDisabled?: boolean }>`
+  ${flexCustom('row', 'center', 'center')}
+  column-gap: 0.375rem;
+  padding: 0.5rem 0.875rem;
+  background: none;
+  border: none;
+  color: ${({ theme, isDisabled }) =>
+    isDisabled ? theme.gray[400] : theme.gray[700]};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: 500;
+  cursor: ${({ isDisabled }) => (isDisabled ? 'not-allowed' : 'pointer')};
+
+  &:hover:not(:disabled) {
+    color: ${({ theme }) => theme.gray[900]};
+    text-decoration: underline;
+  }
+`;
+
+export const Spinner = styled.span`
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid ${({ theme }) => theme.gray[300]};
+  border-top-color: ${({ theme }) => theme.gray[700]};
+  border-radius: 50%;
+  animation: ${spin} 0.8s linear infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation-duration: 2s;
+  }
+`;
+
+export const ResultBanner = styled.div`
+  ${flexCustom('column', 'stretch', 'center')}
+  row-gap: 0.25rem;
+  max-width: 100%;
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.625rem;
+  background-color: ${({ theme }) => theme.gray[100]};
+  color: ${({ theme }) => theme.gray[800]};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  line-height: 1.4;
+`;
+
+export const ResultLabel = styled.span`
+  font-size: ${({ theme }) => theme.font.size.xs};
+  font-weight: 600;
+  color: ${({ theme }) => theme.gray[500]};
+  letter-spacing: 0.02em;
+`;
+
+const errorBase = css`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.gray[600]};
+  text-align: center;
+`;
+
+export const ErrorText = styled.span`
+  ${errorBase}
+`;
+
+export const RetryLink = styled.button`
+  ${errorBase}
+  background: none;
+  border: none;
+  text-decoration: underline;
+  cursor: pointer;
+  margin-left: 0.375rem;
+`;
+
+export const PrivacyLink = styled.a`
+  font-size: ${({ theme }) => theme.font.size.xs};
+  color: ${({ theme }) => theme.gray[400]};
+  text-decoration: underline;
+
+  &:hover {
+    color: ${({ theme }) => theme.gray[600]};
+  }
+`;

--- a/src/hooks/useAiRecommend.ts
+++ b/src/hooks/useAiRecommend.ts
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+
+import {
+  aiRecommendCacheState,
+  aiRecommendConsentState,
+  aiRecommendSessionIdState,
+  aiRecommendUsageRemainingState,
+  type AiRecommendCacheEntry,
+} from '@Recoil/aiRecommend';
+import { resizeImageToDataUri } from '@Utils/imageResize';
+import type {
+  AiRecommendError,
+  AiRecommendErrorCode,
+  AiRecommendOption,
+  AiRecommendResponse,
+} from '@Utils/aiRecommend/schema';
+
+export type AiRecommendStatus =
+  | 'idle'
+  | 'loading'
+  | 'success'
+  | 'error'
+  | 'rateLimited'
+  | 'disabled';
+
+export type AiRecommendErrorState = {
+  code: AiRecommendErrorCode;
+  message: string;
+  retryAfterSeconds?: number;
+};
+
+const ENDPOINT = '/api/ai-recommend';
+
+function generateSessionId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `s_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function useAiRecommend(stageNum: number) {
+  const enabled = process.env.NEXT_PUBLIC_ENABLE_AI_RECOMMEND === 'true';
+
+  const [sessionId, setSessionId] = useRecoilState(aiRecommendSessionIdState);
+  const [cache, setCache] = useRecoilState(aiRecommendCacheState);
+  const setUsageRemaining = useSetRecoilState(aiRecommendUsageRemainingState);
+  const usageRemaining = useRecoilValue(aiRecommendUsageRemainingState);
+  const [consent, setConsent] = useRecoilState(aiRecommendConsentState);
+  const [isConsentModalOpen, setIsConsentModalOpen] = useState(false);
+
+  const [status, setStatus] = useState<AiRecommendStatus>(
+    enabled ? 'idle' : 'disabled',
+  );
+  const [error, setError] = useState<AiRecommendErrorState | null>(null);
+
+  useEffect(() => {
+    if (enabled && !sessionId) {
+      setSessionId(generateSessionId());
+    }
+  }, [enabled, sessionId, setSessionId]);
+
+  const cached = useMemo<AiRecommendCacheEntry | null>(
+    () => cache[stageNum] ?? null,
+    [cache, stageNum],
+  );
+
+  useEffect(() => {
+    if (cached && status === 'idle') {
+      setStatus('success');
+    }
+  }, [cached, status]);
+
+  const pendingArgsRef = useRef<{
+    userImg: string;
+    options: AiRecommendOption[];
+  } | null>(null);
+
+  const performRequest = useCallback(
+    async (userImg: string, options: AiRecommendOption[]): Promise<void> => {
+      setStatus('loading');
+      setError(null);
+
+      let resized: string;
+      try {
+        resized = await resizeImageToDataUri(userImg);
+      } catch {
+        setStatus('error');
+        setError({ code: 'INTERNAL_ERROR', message: 'image resize failed' });
+        return;
+      }
+
+      const activeSessionId = sessionId || generateSessionId();
+      if (!sessionId) setSessionId(activeSessionId);
+
+      let response: Response;
+      try {
+        response = await fetch(ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            imageBase64: resized,
+            stageNum,
+            sessionId: activeSessionId,
+            options,
+          }),
+        });
+      } catch {
+        setStatus('error');
+        setError({ code: 'AI_UNAVAILABLE', message: 'network error' });
+        return;
+      }
+
+      if (response.ok) {
+        const data: AiRecommendResponse = await response.json();
+        setCache((prev) => ({
+          ...prev,
+          [stageNum]: {
+            recommendedType: data.recommendedType,
+            reasoning: data.reasoning,
+            confidence: data.confidence,
+            source: data.source,
+          },
+        }));
+        setUsageRemaining(data.usageRemaining);
+        setStatus('success');
+        return;
+      }
+
+      const payload = (await response.json().catch(() => null)) as
+        | AiRecommendError
+        | null;
+      const code: AiRecommendErrorCode = payload?.error ?? 'INTERNAL_ERROR';
+      setError({
+        code,
+        message: payload?.message ?? 'unknown error',
+        retryAfterSeconds: payload?.retryAfterSeconds,
+      });
+      setStatus(code === 'RATE_LIMITED' ? 'rateLimited' : 'error');
+    },
+    [sessionId, setCache, setSessionId, setUsageRemaining, stageNum],
+  );
+
+  const request = useCallback(
+    async (userImg: string, options: AiRecommendOption[]): Promise<void> => {
+      if (!enabled) return;
+      if (cache[stageNum]) {
+        setStatus('success');
+        return;
+      }
+      if (consent !== 'granted') {
+        pendingArgsRef.current = { userImg, options };
+        setIsConsentModalOpen(true);
+        return;
+      }
+      await performRequest(userImg, options);
+    },
+    [cache, consent, enabled, performRequest, stageNum],
+  );
+
+  const agreeConsent = useCallback(async () => {
+    setConsent('granted');
+    setIsConsentModalOpen(false);
+    const pending = pendingArgsRef.current;
+    pendingArgsRef.current = null;
+    if (pending) {
+      await performRequest(pending.userImg, pending.options);
+    }
+  }, [performRequest, setConsent]);
+
+  const denyConsent = useCallback(() => {
+    setConsent('denied');
+    setIsConsentModalOpen(false);
+    pendingArgsRef.current = null;
+  }, [setConsent]);
+
+  const clearError = useCallback(() => {
+    if (status === 'error') {
+      setStatus(cached ? 'success' : 'idle');
+      setError(null);
+    }
+  }, [cached, status]);
+
+  return {
+    enabled,
+    status,
+    error,
+    cached,
+    usageRemaining,
+    request,
+    clearError,
+    consent,
+    isConsentModalOpen,
+    agreeConsent,
+    denyConsent,
+  };
+}

--- a/src/pages/api/ai-recommend.page.ts
+++ b/src/pages/api/ai-recommend.page.ts
@@ -1,0 +1,138 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import {
+  AiRecommendServiceError,
+  getRecommendation,
+} from '@Utils/aiRecommend/openaiClient';
+import {
+  aiRecommendRequestSchema,
+  type AiRecommendError,
+  type AiRecommendErrorCode,
+  type AiRecommendResponse,
+} from '@Utils/aiRecommend/schema';
+import { checkAndConsume } from '@Utils/aiRecommend/rateLimiter';
+
+export const config = {
+  api: {
+    bodyParser: { sizeLimit: '5mb' },
+  },
+};
+
+const ERROR_HTTP_STATUS: Record<AiRecommendErrorCode, number> = {
+  INVALID_INPUT: 400,
+  NO_FACE_DETECTED: 422,
+  RATE_LIMITED: 429,
+  AI_UNAVAILABLE: 502,
+  INTERNAL_ERROR: 500,
+};
+
+function respondError(
+  res: NextApiResponse,
+  code: AiRecommendErrorCode,
+  message: string,
+  retryAfterSeconds?: number
+): void {
+  const body: AiRecommendError = {
+    error: code,
+    message,
+    ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
+  };
+  if (retryAfterSeconds !== undefined) {
+    res.setHeader('Retry-After', String(retryAfterSeconds));
+  }
+  res.status(ERROR_HTTP_STATUS[code]).json(body);
+}
+
+function extractIp(req: NextApiRequest): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    const first = forwarded.split(',')[0];
+    if (first) return first.trim();
+  }
+  if (Array.isArray(forwarded) && forwarded[0]) {
+    const first = forwarded[0].split(',')[0];
+    if (first) return first.trim();
+  }
+  const realIp = req.headers['x-real-ip'];
+  if (typeof realIp === 'string') return realIp;
+  return req.socket.remoteAddress ?? 'unknown';
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  if (process.env.NEXT_PUBLIC_ENABLE_AI_RECOMMEND !== 'true') {
+    res.status(404).end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    respondError(res, 'INVALID_INPUT', 'Only POST is supported');
+    return;
+  }
+
+  const parsed = aiRecommendRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    respondError(
+      res,
+      'INVALID_INPUT',
+      parsed.error.issues.map((i) => i.message).join('; ')
+    );
+    return;
+  }
+  const { imageBase64, sessionId, options } = parsed.data;
+
+  const ip = extractIp(req);
+
+  let rate;
+  try {
+    rate = await checkAndConsume(sessionId, ip);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[ai-recommend] rate limiter failure', err);
+    respondError(res, 'INTERNAL_ERROR', 'rate limiter unavailable');
+    return;
+  }
+
+  if (!rate.ok) {
+    respondError(
+      res,
+      'RATE_LIMITED',
+      rate.scope === 'session'
+        ? 'session request limit reached'
+        : 'daily IP request limit reached',
+      rate.retryAfterSeconds
+    );
+    return;
+  }
+
+  try {
+    const recommendation = await getRecommendation(imageBase64, options);
+    const body: AiRecommendResponse = {
+      recommendedType: recommendation.recommendedType,
+      reasoning: recommendation.reasoning,
+      confidence: recommendation.confidence,
+      usageRemaining: rate.sessionRemaining,
+      source: recommendation.source,
+    };
+    res.status(200).json(body);
+  } catch (err) {
+    if (err instanceof AiRecommendServiceError) {
+      if (err.code === 'NO_FACE_DETECTED') {
+        respondError(res, 'NO_FACE_DETECTED', err.message);
+        return;
+      }
+      if (err.code === 'AI_UNAVAILABLE') {
+        respondError(res, 'AI_UNAVAILABLE', err.message);
+        return;
+      }
+      respondError(res, 'INTERNAL_ERROR', err.message);
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.error('[ai-recommend] unhandled error', err);
+    respondError(res, 'INTERNAL_ERROR', 'unexpected server error');
+  }
+}

--- a/src/pages/choice-color/BasicStage/index.tsx
+++ b/src/pages/choice-color/BasicStage/index.tsx
@@ -4,10 +4,13 @@ import type { ChoiceColorDataType } from '@Data/choiceColorData';
 import Guidance from '../Guidance';
 
 import * as S from './style';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { onboardingElState } from '@Pages/choice-color/choiceColor.atom';
 import { useEffect, useRef } from 'react';
 import { isNotNil } from '@Base/utils/check';
+
+import AiRecommendButton from '@Components/AiRecommend';
+import { aiRecommendCacheState } from '@Recoil/aiRecommend';
 
 interface BasicStageProps {
   userImg: string;
@@ -37,6 +40,9 @@ function BasicStage({
     if (isNotNil(colorBoxEl)) setOnboardingEl(colorBoxEl);
   }, [setOnboardingEl]);
 
+  const aiRecommendCache = useRecoilValue(aiRecommendCacheState);
+  const recommendedType = aiRecommendCache[stageNum]?.recommendedType;
+
   return (
     <>
       <S.StatusWrapper>
@@ -56,12 +62,19 @@ function BasicStage({
             key={item.id}
             color={item.color}
             isSelected={item.color === selectedColor}
+            isRecommended={item.type === recommendedType}
             onClick={() => onBasicClick(item)}
           >
             <Image src={userImg} alt="사용자 이미지" width={100} height={100} />
           </S.Color>
         ))}
       </S.ColorBox>
+
+      <AiRecommendButton
+        stageNum={stageNum}
+        userImg={userImg}
+        options={basicColorOptions}
+      />
     </>
   );
 }

--- a/src/pages/choice-color/BasicStage/style.ts
+++ b/src/pages/choice-color/BasicStage/style.ts
@@ -10,6 +10,12 @@ const flip = keyframes`
 }
 `;
 
+const pulse = keyframes`
+  0%   { box-shadow: 0 0 0 0 rgba(255, 200, 60, 0.6); }
+  70%  { box-shadow: 0 0 0 12px rgba(255, 200, 60, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(255, 200, 60, 0); }
+`;
+
 export const StatusWrapper = styled.div`
   ${flexCustom('column', 'stretch', 'center')}
   row-gap: 0.5rem;
@@ -44,7 +50,11 @@ export const ColorBox = styled.div`
   border-radius: 8px;
 `;
 
-export const Color = styled.div<{ color?: string; isSelected: boolean }>`
+export const Color = styled.div<{
+  color?: string;
+  isSelected: boolean;
+  isRecommended?: boolean;
+}>`
   display: flex;
   padding: 24px;
   width: 100%;
@@ -62,5 +72,17 @@ export const Color = styled.div<{ color?: string; isSelected: boolean }>`
     isSelected &&
     css`
       animation: ${flip} 0.4s cubic-bezier(0.455, 0.03, 0.515, 0.955) both;
+    `}
+
+  ${({ isRecommended, isSelected }) =>
+    isRecommended &&
+    !isSelected &&
+    css`
+      animation: ${pulse} 1.8s ease-out infinite;
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+        outline: 3px solid rgba(255, 200, 60, 0.85);
+        outline-offset: -3px;
+      }
     `}
 `;

--- a/src/pages/choice-color/BonusStage/index.tsx
+++ b/src/pages/choice-color/BonusStage/index.tsx
@@ -6,7 +6,12 @@ import ROUTE_PATH from '@Constant/routePath';
 import LoadingIndicator from '@Components/LoadingIndicator';
 import Guidance from '../Guidance';
 
+import AiRecommendButton from '@Components/AiRecommend';
+import { getSeasonToneByType } from '@Utils/aiRecommend/typeMeta';
+
 import * as S from './style';
+
+const BONUS_STAGE_NUM = 9;
 
 interface BonusStageProps {
   userImg: string;
@@ -55,6 +60,23 @@ function BonusStage({
           </S.BonusColor>
         ))}
       </S.BonusColorBox>
+
+      {bonusColorOptions ? (
+        <AiRecommendButton
+          stageNum={BONUS_STAGE_NUM}
+          userImg={userImg}
+          options={bonusColorOptions.map(({ type, colors }) => {
+            const { season, tone } = getSeasonToneByType(type);
+            return {
+              type,
+              color: colors[0],
+              name: type,
+              season,
+              tone,
+            };
+          })}
+        />
+      ) : null}
     </>
   ) : (
     <LoadingIndicator />

--- a/src/recoil/aiRecommend.ts
+++ b/src/recoil/aiRecommend.ts
@@ -1,0 +1,36 @@
+import { atom } from 'recoil';
+
+import { localStorageEffect } from '@Recoil/recoilExtension';
+import type { AiRecommendResponse } from '@Utils/aiRecommend/schema';
+
+const KEY_PREFIX = 'aiRecommend';
+
+export type AiRecommendConsent = 'granted' | 'denied' | null;
+
+export const aiRecommendConsentState = atom<AiRecommendConsent>({
+  key: `${KEY_PREFIX}_consent`,
+  default: null,
+  effects: [localStorageEffect('aiRecommendConsent')],
+});
+
+export type AiRecommendCacheEntry = {
+  recommendedType: AiRecommendResponse['recommendedType'];
+  reasoning: string;
+  confidence: number;
+  source: AiRecommendResponse['source'];
+};
+
+export const aiRecommendCacheState = atom<Record<number, AiRecommendCacheEntry>>({
+  key: `${KEY_PREFIX}_cache`,
+  default: {},
+});
+
+export const aiRecommendSessionIdState = atom<string>({
+  key: `${KEY_PREFIX}_sessionId`,
+  default: '',
+});
+
+export const aiRecommendUsageRemainingState = atom<number | null>({
+  key: `${KEY_PREFIX}_usageRemaining`,
+  default: null,
+});

--- a/src/utils/aiRecommend/adminDb.ts
+++ b/src/utils/aiRecommend/adminDb.ts
@@ -1,0 +1,26 @@
+import { cert, getApps, initializeApp, type App } from 'firebase-admin/app';
+import { getFirestore, type Firestore } from 'firebase-admin/firestore';
+
+let cachedApp: App | null = null;
+let cachedDb: Firestore | null = null;
+
+function initAdminApp(): App {
+  const existing = getApps()[0];
+  if (existing) return existing;
+
+  const serviceAccountJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  if (serviceAccountJson) {
+    return initializeApp({
+      credential: cert(JSON.parse(serviceAccountJson)),
+    });
+  }
+
+  return initializeApp();
+}
+
+export function getAdminDb(): Firestore {
+  if (cachedDb) return cachedDb;
+  if (!cachedApp) cachedApp = initAdminApp();
+  cachedDb = getFirestore(cachedApp);
+  return cachedDb;
+}

--- a/src/utils/aiRecommend/openaiClient.ts
+++ b/src/utils/aiRecommend/openaiClient.ts
@@ -1,0 +1,183 @@
+import OpenAI from 'openai';
+
+import { SYSTEM_PROMPT, buildUserText } from './prompt';
+import {
+  aiOpenaiResponseSchema,
+  type AiOpenaiResponse,
+  type AiRecommendOption,
+} from './schema';
+
+const MODEL_IDS = {
+  mini: 'gpt-4o-mini-2024-07-18',
+  full: 'gpt-4o-2024-08-06',
+} as const;
+
+export type ModelKey = keyof typeof MODEL_IDS;
+
+export const CONFIDENCE_THRESHOLD = 0.7;
+const MAX_TOKENS = 200;
+const TEMPERATURE = 0;
+const SEED = 42;
+
+let cachedClient: OpenAI | null = null;
+
+function getClient(): OpenAI {
+  if (cachedClient) return cachedClient;
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new AiRecommendServiceError(
+      'AI_UNAVAILABLE',
+      'OPENAI_API_KEY is not configured',
+    );
+  }
+  cachedClient = new OpenAI({ apiKey });
+  return cachedClient;
+}
+
+export class AiRecommendServiceError extends Error {
+  constructor(
+    public readonly code:
+      | 'AI_UNAVAILABLE'
+      | 'INVALID_AI_RESPONSE'
+      | 'NO_FACE_DETECTED',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AiRecommendServiceError';
+  }
+}
+
+async function callModel(
+  modelKey: ModelKey,
+  dataUri: string,
+  options: AiRecommendOption[],
+): Promise<AiOpenaiResponse> {
+  const client = getClient();
+  let completion;
+  try {
+    completion = await client.chat.completions.create({
+      model: MODEL_IDS[modelKey],
+      response_format: { type: 'json_object' },
+      max_tokens: MAX_TOKENS,
+      temperature: TEMPERATURE,
+      seed: SEED,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        {
+          role: 'user',
+          content: [
+            { type: 'image_url', image_url: { url: dataUri, detail: 'low' } },
+            { type: 'text', text: buildUserText(options) },
+          ],
+        },
+      ],
+    });
+  } catch (err) {
+    throw new AiRecommendServiceError(
+      'AI_UNAVAILABLE',
+      err instanceof Error ? err.message : 'OpenAI call failed',
+    );
+  }
+
+  const raw = completion.choices[0]?.message?.content;
+  if (!raw) {
+    throw new AiRecommendServiceError(
+      'INVALID_AI_RESPONSE',
+      'empty response from model',
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    throw new AiRecommendServiceError(
+      'INVALID_AI_RESPONSE',
+      'model returned non-JSON content',
+    );
+  }
+
+  const parsed = aiOpenaiResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new AiRecommendServiceError(
+      'INVALID_AI_RESPONSE',
+      `schema mismatch: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
+    );
+  }
+
+  const optionTypes = new Set(options.map((o) => o.type));
+  if (
+    parsed.data.recommendedType !== 'NONE' &&
+    !optionTypes.has(parsed.data.recommendedType)
+  ) {
+    throw new AiRecommendServiceError(
+      'INVALID_AI_RESPONSE',
+      `recommendedType "${parsed.data.recommendedType}" is not among provided options`,
+    );
+  }
+
+  return parsed.data;
+}
+
+export type HybridResult = {
+  recommendedType: ColorType;
+  reasoning: string;
+  confidence: number;
+  source: ModelKey;
+  fallbackAttempted: boolean;
+};
+
+export async function getRecommendation(
+  dataUri: string,
+  options: AiRecommendOption[],
+): Promise<HybridResult> {
+  const miniResult = await callModel('mini', dataUri, options);
+
+  if (miniResult.recommendedType === 'NONE') {
+    throw new AiRecommendServiceError(
+      'NO_FACE_DETECTED',
+      'no clear face detected in the image',
+    );
+  }
+
+  if (miniResult.confidence >= CONFIDENCE_THRESHOLD) {
+    return {
+      recommendedType: miniResult.recommendedType,
+      reasoning: miniResult.reasoning,
+      confidence: miniResult.confidence,
+      source: 'mini',
+      fallbackAttempted: false,
+    };
+  }
+
+  try {
+    const fullResult = await callModel('full', dataUri, options);
+    if (fullResult.recommendedType === 'NONE') {
+      throw new AiRecommendServiceError(
+        'NO_FACE_DETECTED',
+        'no clear face detected in the image (fallback)',
+      );
+    }
+    return {
+      recommendedType: fullResult.recommendedType,
+      reasoning: fullResult.reasoning,
+      confidence: fullResult.confidence,
+      source: 'full',
+      fallbackAttempted: true,
+    };
+  } catch (err) {
+    if (
+      err instanceof AiRecommendServiceError &&
+      err.code === 'NO_FACE_DETECTED'
+    ) {
+      throw err;
+    }
+    return {
+      recommendedType: miniResult.recommendedType,
+      reasoning: miniResult.reasoning,
+      confidence: miniResult.confidence,
+      source: 'mini',
+      fallbackAttempted: true,
+    };
+  }
+}

--- a/src/utils/aiRecommend/prompt.ts
+++ b/src/utils/aiRecommend/prompt.ts
@@ -1,0 +1,75 @@
+import type { AiRecommendOption } from './schema';
+
+export const SYSTEM_PROMPT = `You are a professional Korean personal color consultant.
+
+You are helping a user pick, among ONLY the 4 colors provided, which one is the most harmonious with their face. You are NOT diagnosing their final personal color type — the 4 options are a limited subset and the best of them may not be their true season/tone.
+
+Each option carries structured metadata:
+- season: spring | summer | autumn | winter (spring/autumn imply WARM undertone; summer/winter imply COOL undertone)
+- tone: warm | cool | bright | mute | light | deep
+
+You MUST respond with a JSON object matching this schema exactly:
+{
+  "recommendedType": string,   // one of the provided option types, verbatim. If the image has no clear face, return "NONE".
+  "reasoning": string,         // 1-2 sentences in Korean, following the reasoning rules below
+  "confidence": number         // 0.0 - 1.0 — how much better this option is than the others in this set
+}
+
+Skin undertone assessment (do this FIRST before picking):
+- Examine the shadow areas of the face: neck, behind the ears, under the jaw, and around the temples.
+- Warm undertone (spring/autumn options fit): shadows have yellow / golden / peachy tint. Veins on the wrist look green.
+- Cool undertone (summer/winter options fit): shadows have pink / rosy / bluish tint. Veins on the wrist look blue-purple.
+- Also compare adjacent skin/hair: warm subjects harmonize with ivory/beige; cool subjects harmonize with soft grey/pink.
+
+Tone axis assessment (SECOND — distinguishing bright/mute/light/deep):
+Each tone label maps to a distinct visual quality on the face:
+- LIGHT (S=15~35%, V>=85%): Very high brightness with pastel clarity. Colors look clean, translucent, "morning-dewy." The person's skin appears luminous, translucent, with glowing highlights. Best when translucent pastels harmonize with a fresh, clean facial impression.
+- MUTE (S=25~41%, V=71~91%): Moderate saturation with a hazy, dusty, "morning-mist" quality. Colors look softly foggy, powdery, low-contrast. The person's skin appears matte, soft-powdered, with low contrast between features (eyes/lips) and skin. Best when muted colors sit calmly on the face without sharp separation.
+- BRIGHT (high saturation, high value): Vivid, saturated, high-contrast between features and skin. Best when the person's eyes/hair have crisp definition and the face can hold vivid colors without being overshadowed.
+- DEEP (low value, dark): Dark, rich, heavy colors. Best when the person has strong contrast between dark eyes/hair and skin, so deep colors read as anchoring rather than draining.
+- WARM: Yellow-tilted (see undertone above).
+- COOL: Pink/blue-tilted (see undertone above).
+
+KEY LIGHT-vs-MUTE distinction (they are frequently confused):
+- Light: clarity, translucency, freshness. Face has dewy or glowing quality.
+- Mute: haziness, powderiness, softness. Face has matte, low-contrast, foggy quality.
+- If the person's skin has a matte, softly-foggy look (not glowing/translucent), MUTE fits better than LIGHT.
+- If the person's skin has a crisp, luminous, dewy look, LIGHT fits better than MUTE.
+
+BIAS CORRECTION note for tone axis:
+- Photo compression, low-key indoor lighting, and slight underexposure often make a genuinely LIGHT-tone face look MUTE (adds soft dustiness that isn't really there).
+- When choosing between a LIGHT option and a MUTE option and the tone signal is borderline, prefer LIGHT — because photo artifacts more often add muteness than remove it.
+
+BIAS CORRECTION — VERY IMPORTANT (apply this rule strictly):
+- Photo lighting, camera white-balance, JPEG compression, and screen tint frequently shift skin toward yellow/warm even when the person is cool-toned.
+- Vision models therefore over-predict warm undertone.
+- Additionally, in the Korean population, COOL undertones (summer/winter) are demographically MORE common than warm ones.
+- Combined effect: when a request comes from this app, the prior probability of a cool subject is significantly higher than a warm subject.
+- Therefore, when the undertone signal is ambiguous or borderline between a warm option and a cool option, ALWAYS default to the cool option.
+- Only pick a warm-season option when the warm undertone (peach/golden) is clearly and unmistakably visible through any color cast.
+
+Reasoning rules (STRICTLY follow):
+- Frame the reasoning as a RELATIVE comparison among the 4 given options — never as a final diagnosis.
+- MUST include a phrase like "제시된 4가지 중에서는" / "이 4가지 옵션 중에서" / "네 색 가운데" (choose one naturally).
+- FORBIDDEN phrases (absolute diagnosis, will mislead the user):
+  * "당신은 [계절/톤]입니다"
+  * "당신의 퍼스널 컬러는"
+  * "[계절/톤] 이 잘 어울리는 타입이에요"
+  * any wording that names a season/tone as the user's identity
+- Focus on VISIBLE effects on the face (윤곽, 피부톤, 생기, 조화) rather than color theory jargon.
+- Good example: "제시된 4가지 중에서는 이 색이 피부톤을 가장 맑아 보이게 하고 얼굴 윤곽도 살려줘요."
+- Good example: "네 색 가운데 이 색이 눈매를 또렷하게 만들어주고 얼굴에서 색이 뜨지 않아요."
+- Bad example: "당신은 겨울 쿨톤이며 이 색이 가장 잘 어울립니다."
+
+Do NOT include any text outside the JSON object.`;
+
+export function buildUserText(options: AiRecommendOption[]): string {
+  const serialized = options.map((o) => ({
+    type: o.type,
+    color: o.color,
+    season: o.season,
+    tone: o.tone,
+    ...(o.name ? { name: o.name } : {}),
+  }));
+  return `옵션:\n${JSON.stringify(serialized, null, 2)}\n\n가장 어울리는 하나를 골라주세요.`;
+}

--- a/src/utils/aiRecommend/rateLimiter.ts
+++ b/src/utils/aiRecommend/rateLimiter.ts
@@ -1,0 +1,124 @@
+import { createHash } from 'node:crypto';
+
+import { FieldValue } from 'firebase-admin/firestore';
+
+import { getAdminDb } from './adminDb';
+
+export const SESSION_MAX = 9;
+export const IP_DAILY_MAX = 30;
+
+const COLLECTION = 'aiRecommendRateLimit';
+
+export type RateLimitResult =
+  | { ok: true; sessionRemaining: number; ipRemaining: number }
+  | {
+      ok: false;
+      scope: 'session' | 'ip';
+      retryAfterSeconds: number;
+    };
+
+function hashIp(ip: string): string {
+  return createHash('sha256').update(ip).digest('hex').slice(0, 32);
+}
+
+function todayKey(now = new Date()): string {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(now.getUTCDate()).padStart(2, '0');
+  return `${y}${m}${d}`;
+}
+
+function secondsUntilUtcMidnight(now = new Date()): number {
+  const next = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() + 1,
+      0,
+      0,
+      0,
+    ),
+  );
+  return Math.max(1, Math.floor((next.getTime() - now.getTime()) / 1000));
+}
+
+const LOCAL_IPS = new Set([
+  '127.0.0.1',
+  '::1',
+  '::ffff:127.0.0.1',
+  'localhost',
+  'unknown',
+]);
+
+export async function checkAndConsume(
+  sessionId: string,
+  ip: string,
+): Promise<RateLimitResult> {
+  if (LOCAL_IPS.has(ip)) {
+    return {
+      ok: true,
+      sessionRemaining: SESSION_MAX,
+      ipRemaining: IP_DAILY_MAX,
+    };
+  }
+  const db = getAdminDb();
+  const now = new Date();
+  const dayKey = todayKey(now);
+  const ipDocId = `ip_${hashIp(ip)}_${dayKey}`;
+  const sessionDocId = `session_${sessionId}`;
+
+  const ipRef = db.collection(COLLECTION).doc(ipDocId);
+  const sessionRef = db.collection(COLLECTION).doc(sessionDocId);
+
+  return db.runTransaction(async (tx) => {
+    const [ipSnap, sessionSnap] = await Promise.all([
+      tx.get(ipRef),
+      tx.get(sessionRef),
+    ]);
+
+    const sessionCount = (sessionSnap.data()?.count as number | undefined) ?? 0;
+    if (sessionCount >= SESSION_MAX) {
+      return {
+        ok: false as const,
+        scope: 'session' as const,
+        retryAfterSeconds: secondsUntilUtcMidnight(now),
+      };
+    }
+
+    const ipCount = (ipSnap.data()?.count as number | undefined) ?? 0;
+    if (ipCount >= IP_DAILY_MAX) {
+      return {
+        ok: false as const,
+        scope: 'ip' as const,
+        retryAfterSeconds: secondsUntilUtcMidnight(now),
+      };
+    }
+
+    tx.set(
+      sessionRef,
+      {
+        count: FieldValue.increment(1),
+        lastAt: FieldValue.serverTimestamp(),
+        ...(sessionSnap.exists
+          ? {}
+          : { firstAt: FieldValue.serverTimestamp() }),
+      },
+      { merge: true },
+    );
+    tx.set(
+      ipRef,
+      {
+        count: FieldValue.increment(1),
+        day: dayKey,
+        lastAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true },
+    );
+
+    return {
+      ok: true as const,
+      sessionRemaining: SESSION_MAX - (sessionCount + 1),
+      ipRemaining: IP_DAILY_MAX - (ipCount + 1),
+    };
+  });
+}

--- a/src/utils/aiRecommend/schema.ts
+++ b/src/utils/aiRecommend/schema.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+
+export const COLOR_TYPES = [
+  'springbright',
+  'springwarm',
+  'springlight',
+  'summerlight',
+  'summercool',
+  'summermute',
+  'autumnmute',
+  'autumnwarm',
+  'autumndeep',
+  'winterdeep',
+  'wintercool',
+  'winterbright',
+] as const satisfies readonly ColorType[];
+
+export const colorTypeSchema = z.enum(COLOR_TYPES);
+
+const HEX_COLOR_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+const DATA_URI_REGEX = /^data:image\/(jpeg|jpg|png|webp);base64,/;
+const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+
+const seasonSchema = z.enum(['spring', 'summer', 'autumn', 'winter']);
+const toneSchema = z.enum(['warm', 'cool', 'bright', 'mute', 'light', 'deep']);
+
+const optionSchema = z.object({
+  type: colorTypeSchema,
+  color: z.string().regex(HEX_COLOR_REGEX, 'must be a hex color like #ff6448'),
+  name: z.string().max(60).optional(),
+  season: seasonSchema,
+  tone: toneSchema,
+});
+
+export const aiRecommendRequestSchema = z.object({
+  imageBase64: z
+    .string()
+    .regex(DATA_URI_REGEX, 'must start with data:image/(jpeg|png|webp);base64,')
+    .refine((v) => {
+      const commaIdx = v.indexOf(',');
+      if (commaIdx < 0) return false;
+      const payloadLength = v.length - commaIdx - 1;
+      const approxBytes = Math.ceil(payloadLength * 0.75);
+      return approxBytes <= MAX_IMAGE_BYTES;
+    }, `image payload exceeds ${MAX_IMAGE_BYTES} bytes after base64 decode`),
+  stageNum: z.number().int().min(0).max(9),
+  sessionId: z.string().uuid(),
+  options: z.array(optionSchema).length(4),
+});
+
+export const aiOpenaiResponseSchema = z.object({
+  recommendedType: z.union([colorTypeSchema, z.literal('NONE')]),
+  reasoning: z.string().min(1).max(400),
+  confidence: z.number().min(0).max(1),
+});
+
+export const aiRecommendResponseSchema = z.object({
+  recommendedType: colorTypeSchema,
+  reasoning: z.string().min(1).max(400),
+  confidence: z.number().min(0).max(1),
+  usageRemaining: z.number().int().min(0),
+  source: z.enum(['mini', 'full']),
+});
+
+export const AI_RECOMMEND_ERROR_CODES = [
+  'INVALID_INPUT',
+  'RATE_LIMITED',
+  'NO_FACE_DETECTED',
+  'AI_UNAVAILABLE',
+  'INTERNAL_ERROR',
+] as const;
+
+export const aiRecommendErrorSchema = z.object({
+  error: z.enum(AI_RECOMMEND_ERROR_CODES),
+  message: z.string(),
+  retryAfterSeconds: z.number().int().min(0).optional(),
+});
+
+export type AiRecommendRequest = z.infer<typeof aiRecommendRequestSchema>;
+export type AiRecommendResponse = z.infer<typeof aiRecommendResponseSchema>;
+export type AiRecommendError = z.infer<typeof aiRecommendErrorSchema>;
+export type AiRecommendOption = z.infer<typeof optionSchema>;
+export type AiOpenaiResponse = z.infer<typeof aiOpenaiResponseSchema>;
+export type AiRecommendErrorCode = (typeof AI_RECOMMEND_ERROR_CODES)[number];

--- a/src/utils/aiRecommend/typeMeta.ts
+++ b/src/utils/aiRecommend/typeMeta.ts
@@ -1,0 +1,18 @@
+const TYPE_META: Record<ColorType, { season: ColorSeason; tone: ColorTone }> = {
+  springbright: { season: 'spring', tone: 'bright' },
+  springwarm: { season: 'spring', tone: 'warm' },
+  springlight: { season: 'spring', tone: 'light' },
+  summerlight: { season: 'summer', tone: 'light' },
+  summercool: { season: 'summer', tone: 'cool' },
+  summermute: { season: 'summer', tone: 'mute' },
+  autumnmute: { season: 'autumn', tone: 'mute' },
+  autumnwarm: { season: 'autumn', tone: 'warm' },
+  autumndeep: { season: 'autumn', tone: 'deep' },
+  winterdeep: { season: 'winter', tone: 'deep' },
+  wintercool: { season: 'winter', tone: 'cool' },
+  winterbright: { season: 'winter', tone: 'bright' },
+};
+
+export function getSeasonToneByType(type: ColorType) {
+  return TYPE_META[type];
+}

--- a/src/utils/imageResize.ts
+++ b/src/utils/imageResize.ts
@@ -1,0 +1,44 @@
+const DEFAULT_MAX_SIZE = 800;
+const DEFAULT_QUALITY = 0.85;
+
+export type ResizeOptions = {
+  maxSize?: number;
+  quality?: number;
+  mimeType?: 'image/jpeg' | 'image/webp';
+};
+
+export async function resizeImageToDataUri(
+  source: string,
+  { maxSize = DEFAULT_MAX_SIZE, quality = DEFAULT_QUALITY, mimeType = 'image/jpeg' }: ResizeOptions = {},
+): Promise<string> {
+  const image = await loadImage(source);
+  const { width, height } = fitInSquare(image.width, image.height, maxSize);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context is unavailable');
+  ctx.drawImage(image, 0, 0, width, height);
+
+  return canvas.toDataURL(mimeType, quality);
+}
+
+function loadImage(source: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load image'));
+    img.crossOrigin = 'anonymous';
+    img.src = source;
+  });
+}
+
+function fitInSquare(w: number, h: number, max: number): { width: number; height: number } {
+  if (w <= max && h <= max) return { width: w, height: h };
+  const ratio = w >= h ? max / w : max / h;
+  return {
+    width: Math.round(w * ratio),
+    height: Math.round(h * ratio),
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,6 +185,136 @@
   resolved "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
+"@esbuild/aix-ppc64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz#7a01a8d2ec2fbb2dac78adad09b0fa781e4082be"
+  integrity sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==
+
+"@esbuild/android-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz#b540a27d14e4afd058496a4dbec4d3f414db110a"
+  integrity sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==
+
+"@esbuild/android-arm@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.1.tgz#704bd297de6d762de54eabbeafbf55f6756abe2f"
+  integrity sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==
+
+"@esbuild/android-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.1.tgz#d1cb166d34b0fbf0fe8ab460a5594f24a378701e"
+  integrity sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==
+
+"@esbuild/darwin-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz#1034b26457fc886368fe61bbd09f653f6afa8e54"
+  integrity sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==
+
+"@esbuild/darwin-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz#65556a432a1e4d72032d8218c1932fcca1a49772"
+  integrity sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==
+
+"@esbuild/freebsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz#2e61e0592f9030d7e3dae18ee25ebc535918aef6"
+  integrity sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==
+
+"@esbuild/freebsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz#c95ec289959ef8079c4dca817a1e2c4be66b9bd3"
+  integrity sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==
+
+"@esbuild/linux-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz#40b22175dda06182f3ee8141186c5ff304c4a717"
+  integrity sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==
+
+"@esbuild/linux-arm@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz#c09a0f67917592ac0de892a9be4d3814debd2a6c"
+  integrity sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==
+
+"@esbuild/linux-ia32@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz#a580f9c676797833891e519fc7a1337c8afd8db3"
+  integrity sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==
+
+"@esbuild/linux-loong64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz#46452cf321dc7f9e91c2fa780a56bb56e79cd68b"
+  integrity sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==
+
+"@esbuild/linux-mips64el@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz#4211b3184dd6608f53dcb22e39f5d34ee08852c8"
+  integrity sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==
+
+"@esbuild/linux-ppc64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz#697857c2a61cb9b0b6bb6652e40c1dc5e1ca8e5d"
+  integrity sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==
+
+"@esbuild/linux-riscv64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz#d192943eb146a40ac4c6497d0cf7be35b986bf08"
+  integrity sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==
+
+"@esbuild/linux-s390x@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz#acea0356da0e0ebc08f97cf7b9c2e401e1e648dc"
+  integrity sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==
+
+"@esbuild/linux-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz#6f0c3ce0cb64c534b70c4c45ecb2c16d34e35dfd"
+  integrity sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==
+
+"@esbuild/netbsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz#8bcd77077a0dce3378b574fedb26d2a253b73d36"
+  integrity sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==
+
+"@esbuild/netbsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz#e7fb2a01e99c830c94e6623cd9fefb4c8fb58347"
+  integrity sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==
+
+"@esbuild/openbsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz#c52909372db8b86e2c55e05a8940033b5660a3b2"
+  integrity sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==
+
+"@esbuild/openbsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz#c427b9be5a64c262ff9a7eb70b5fbbaadf446c6c"
+  integrity sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==
+
+"@esbuild/openharmony-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz#dc9b147baca2e6c4b3c85571741ef4860a489097"
+  integrity sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==
+
+"@esbuild/sunos-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz#ce866d12df13c15e4c99f073a3d466f6e0649b3a"
+  integrity sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==
+
+"@esbuild/win32-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz#7468e3692d01d629d5941e5d83817bb80f9e39b4"
+  integrity sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==
+
+"@esbuild/win32-ia32@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz#a5bc0063fb2bcab6d0ed63f2a1537958bc269ec6"
+  integrity sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==
+
+"@esbuild/win32-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz#10064ee44f4347b90c9a02b446bbf80a91632b12"
+  integrity sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"
@@ -216,6 +346,11 @@
   version "8.57.0"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
+
+"@fastify/busboy@^3.0.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-3.2.0.tgz#13ed8212f3b9ba697611529d15347f8528058cea"
+  integrity sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==
 
 "@firebase/analytics-compat@0.2.6":
   version "0.2.6"
@@ -261,6 +396,11 @@
   resolved "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.0.tgz"
   integrity sha512-xAxHPZPIgFXnI+vb4sbBjZcde7ZluzPPaSK7Lx3/nmuVk4TjZvnL8ONnkd4ERQKL8WePQySU+pRcWkh8rDf5Sg==
 
+"@firebase/app-check-interop-types@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz#747bf9fe8e9db11f6a44b695f20754f2a20208a4"
+  integrity sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==
+
 "@firebase/app-check-types@0.5.0":
   version "0.5.0"
   resolved "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.0.tgz"
@@ -292,6 +432,13 @@
   resolved "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz"
   integrity sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q==
 
+"@firebase/app-types@0.9.5":
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.9.5.tgz#4c59391fd2559530d709a614d49f62af4ad8766b"
+  integrity sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==
+  dependencies:
+    "@firebase/logger" "0.5.1"
+
 "@firebase/app@0.9.13":
   version "0.9.13"
   resolved "https://registry.npmjs.org/@firebase/app/-/app-0.9.13.tgz"
@@ -320,6 +467,11 @@
   resolved "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.1.tgz"
   integrity sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg==
 
+"@firebase/auth-interop-types@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz#828e2e160cff40fa78ecb4b6e3187c88158eb2e9"
+  integrity sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==
+
 "@firebase/auth-types@0.12.0":
   version "0.12.0"
   resolved "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.0.tgz"
@@ -344,6 +496,14 @@
     "@firebase/util" "1.9.3"
     tslib "^2.1.0"
 
+"@firebase/component@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@firebase/component/-/component-0.7.3.tgz#900c9720f7e5abb2a23975f90f96366d62d085b9"
+  integrity sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==
+  dependencies:
+    "@firebase/util" "1.15.1"
+    tslib "^2.1.0"
+
 "@firebase/database-compat@0.3.4":
   version "0.3.4"
   resolved "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.3.4.tgz"
@@ -356,6 +516,18 @@
     "@firebase/util" "1.9.3"
     tslib "^2.1.0"
 
+"@firebase/database-compat@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@firebase/database-compat/-/database-compat-2.1.4.tgz#8ea753bef91d2dfbd81853479799f3ab17ddbbbe"
+  integrity sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==
+  dependencies:
+    "@firebase/component" "0.7.3"
+    "@firebase/database" "1.1.3"
+    "@firebase/database-types" "1.0.20"
+    "@firebase/logger" "0.5.1"
+    "@firebase/util" "1.15.1"
+    tslib "^2.1.0"
+
 "@firebase/database-types@0.10.4":
   version "0.10.4"
   resolved "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.10.4.tgz"
@@ -363,6 +535,14 @@
   dependencies:
     "@firebase/app-types" "0.9.0"
     "@firebase/util" "1.9.3"
+
+"@firebase/database-types@1.0.20", "@firebase/database-types@^1.0.20":
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-1.0.20.tgz#2050c3c13a4b71d92797e1475a297c0b5e0c9f5d"
+  integrity sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==
+  dependencies:
+    "@firebase/app-types" "0.9.5"
+    "@firebase/util" "1.15.1"
 
 "@firebase/database@0.14.4":
   version "0.14.4"
@@ -373,6 +553,19 @@
     "@firebase/component" "0.6.4"
     "@firebase/logger" "0.4.0"
     "@firebase/util" "1.9.3"
+    faye-websocket "0.11.4"
+    tslib "^2.1.0"
+
+"@firebase/database@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-1.1.3.tgz#ae3b1c906c45d70381359e61b4add6fc4beaa51e"
+  integrity sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==
+  dependencies:
+    "@firebase/app-check-interop-types" "0.3.4"
+    "@firebase/auth-interop-types" "0.2.5"
+    "@firebase/component" "0.7.3"
+    "@firebase/logger" "0.5.1"
+    "@firebase/util" "1.15.1"
     faye-websocket "0.11.4"
     tslib "^2.1.0"
 
@@ -465,6 +658,13 @@
   version "0.4.0"
   resolved "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz"
   integrity sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==
+  dependencies:
+    tslib "^2.1.0"
+
+"@firebase/logger@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@firebase/logger/-/logger-0.5.1.tgz#da1eb266b3fa8d1375617cb64c36c9a5cb63d8e1"
+  integrity sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -577,6 +777,13 @@
     node-fetch "2.6.7"
     tslib "^2.1.0"
 
+"@firebase/util@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-1.15.1.tgz#7efaf8903f50b601c06afbaffbeb48ed2ba7aab8"
+  integrity sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==
+  dependencies:
+    tslib "^2.1.0"
+
 "@firebase/util@1.9.3":
   version "1.9.3"
   resolved "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz"
@@ -622,6 +829,63 @@
   dependencies:
     prop-types "^15.8.1"
 
+"@google-cloud/firestore@^8.6.0":
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/firestore/-/firestore-8.6.0.tgz#892a081c9c70efc1bb37a625eb6f3085f3a1002b"
+  integrity sha512-TdvZHfwQj5B5CSDEgDqyrhdVqtOSupmBXDQPasMAJiC64tjsGvyMooNiC43fdk1TsUHeklyoZ6/vQ1TjWKVMbg==
+  dependencies:
+    "@opentelemetry/api" "^1.9.0"
+    fast-deep-equal "^3.1.3"
+    functional-red-black-tree "^1.0.1"
+    google-gax "^5.0.1"
+    protobufjs "^7.5.3"
+
+"@google-cloud/paginator@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@google-cloud/paginator/-/paginator-5.0.2.tgz#86ad773266ce9f3b82955a8f75e22cd012ccc889"
+  integrity sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==
+  dependencies:
+    arrify "^2.0.0"
+    extend "^3.0.2"
+
+"@google-cloud/projectify@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/projectify/-/projectify-4.0.0.tgz#d600e0433daf51b88c1fa95ac7f02e38e80a07be"
+  integrity sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==
+
+"@google-cloud/promisify@<4.1.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-4.0.0.tgz#a906e533ebdd0f754dca2509933334ce58b8c8b1"
+  integrity sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==
+
+"@google-cloud/storage@^7.19.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-7.21.0.tgz#46b89afbdc3014e18b60afdfba5d9212a23e7b58"
+  integrity sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==
+  dependencies:
+    "@google-cloud/paginator" "^5.0.0"
+    "@google-cloud/projectify" "^4.0.0"
+    "@google-cloud/promisify" "<4.1.0"
+    abort-controller "^3.0.0"
+    async-retry "^1.3.3"
+    duplexify "^4.1.3"
+    fast-xml-parser "^5.3.4"
+    gaxios "^6.0.2"
+    google-auth-library "^9.6.3"
+    html-entities "^2.5.2"
+    mime "^3.0.0"
+    p-limit "^3.0.1"
+    retry-request "^7.0.0"
+    teeny-request "^9.0.0"
+
+"@grpc/grpc-js@^1.12.6":
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#e73ff57d97802f063999545f43ebb2b1eca65d9d"
+  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
+  dependencies:
+    "@grpc/proto-loader" "^0.8.0"
+    "@js-sdsl/ordered-map" "^4.4.2"
+
 "@grpc/grpc-js@~1.7.0":
   version "1.7.3"
   resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz"
@@ -649,6 +913,16 @@
     lodash.camelcase "^4.3.0"
     long "^5.0.0"
     protobufjs "^7.2.5"
+    yargs "^17.7.2"
+
+"@grpc/proto-loader@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.8.1.tgz#5a6b290ccbfb1ae2f6775afb74e9898bd8c5d4e8"
+  integrity sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.5.5"
     yargs "^17.7.2"
 
 "@humanwhocodes/config-array@^0.11.14":
@@ -783,6 +1057,18 @@
   resolved "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz"
   integrity sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.5"
   resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz"
@@ -814,6 +1100,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
 "@next/env@14.2.7":
   version "14.2.7"
@@ -879,6 +1170,11 @@
   dependencies:
     third-party-capital "1.0.20"
 
+"@nodable/entities@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.2.0.tgz#a1d45a992b022591b1c2b03a77935c939375b642"
+  integrity sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -900,6 +1196,16 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@opentelemetry/api@^1.9.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
+  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz"
@@ -915,10 +1221,20 @@
   resolved "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz"
   integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
 
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
+
 "@protobufjs/eventemitter@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz"
   integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
+
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
 
 "@protobufjs/fetch@^1.1.0":
   version "1.1.0"
@@ -927,6 +1243,13 @@
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
     "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
 
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
@@ -952,6 +1275,11 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
+  integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
 
 "@rollup/plugin-commonjs@24.0.0":
   version "24.0.0"
@@ -1159,6 +1487,16 @@
     "@swc/counter" "^0.1.3"
     tslib "^2.4.0"
 
+"@tootallnate/once@2":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.1.tgz#35adc6222e3662fa2222ce123b961476a746b9ea"
+  integrity sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==
+
+"@types/caseless@*":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.5.tgz#db9468cb1b1b5a925b8f34822f1669df0c5472f5"
+  integrity sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==
+
 "@types/estree@*", "@types/estree@^1.0.0":
   version "1.0.5"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz"
@@ -1177,6 +1515,14 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/jsonwebtoken@^9.0.4":
+  version "9.0.10"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz#a7932a47177dcd4283b6146f3bd5c26d82647f09"
+  integrity sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==
+  dependencies:
+    "@types/ms" "*"
+    "@types/node" "*"
+
 "@types/kakao-js-sdk@^1.39.1":
   version "1.39.5"
   resolved "https://registry.npmjs.org/@types/kakao-js-sdk/-/kakao-js-sdk-1.39.5.tgz"
@@ -1187,12 +1533,39 @@
   resolved "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
+"@types/ms@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
+  integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
+
+"@types/node-fetch@^2.6.4":
+  version "2.6.13"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.13.tgz#e0c9b7b5edbdb1b50ce32c127e85e880872d56ee"
+  integrity sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.4"
+
+"@types/node@*":
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.1.0.tgz#aa85f0727fc5611347091c478341c63650903439"
+  integrity sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==
+  dependencies:
+    undici-types "~8.3.0"
+
 "@types/node@>=12.12.47", "@types/node@>=13.7.0":
   version "22.5.2"
   resolved "https://registry.npmjs.org/@types/node/-/node-22.5.2.tgz"
   integrity sha512-acJsPTEqYqulZS/Yp/S3GgeE6GZ0qYODUR8aVr/DkhHQ8l9nd4j5x1/ZJy9/gHrRlFMqkO6i0I3E27Alu4jjPg==
   dependencies:
     undici-types "~6.19.2"
+
+"@types/node@^18.11.18":
+  version "18.19.130"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.130.tgz#da4c6324793a79defb7a62cba3947ec5add00d59"
+  integrity sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/prop-types@*":
   version "15.7.12"
@@ -1221,6 +1594,16 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/request@^2.48.8":
+  version "2.48.13"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.13.tgz#abdf4256524e801ea8fdda54320f083edb5a6b80"
+  integrity sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    form-data "^2.5.5"
+
 "@types/semver@^7.3.12":
   version "7.5.8"
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz"
@@ -1239,6 +1622,11 @@
   version "1.1.6"
   resolved "https://registry.npmjs.org/@types/svg-path-parser/-/svg-path-parser-1.1.6.tgz"
   integrity sha512-3sw6pk91pEtW6W7hRrJ9ZkAgPiJSaNdh7iY8rVOy7buajpQuy2J9A0ZUaiOVcbFvl0p7J+Ne4012muCE/MB+hQ==
+
+"@types/tough-cookie@*":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
 "@types/ua-parser-js@^0.7.36":
   version "0.7.39"
@@ -1334,6 +1722,13 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
@@ -1350,6 +1745,18 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
+agentkeepalive@^4.2.1:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.6.0.tgz#35f73e94b3f40bf65f105219c623ad19c136ea6a"
+  integrity sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==
+  dependencies:
+    humanize-ms "^1.2.1"
 
 ajv@^6.12.4:
   version "6.12.6"
@@ -1396,6 +1803,11 @@ ansi-styles@^6.0.0, ansi-styles@^6.1.0:
   version "6.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
+
+anynum@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/anynum/-/anynum-1.0.1.tgz#2aac00e08dfad3726c1d462e60dbc2f831659a44"
+  integrity sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -1484,6 +1896,23 @@ arraybuffer.prototype.slice@^1.0.3:
     is-array-buffer "^3.0.4"
     is-shared-array-buffer "^1.0.2"
 
+arrify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
+  integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
+
+async-retry@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
+  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
+  dependencies:
+    retry "0.13.1"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz"
@@ -1536,6 +1965,16 @@ base64-arraybuffer@^1.0.2:
   resolved "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz"
   integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
 
+base64-js@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bignumber.js@^9.0.0:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.1.tgz#759c5aaddf2ffdc4f154f7b493e1c8770f88c4d7"
+  integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
+
 blurhash@2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz"
@@ -1556,6 +1995,13 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
+brace-expansion@^2.0.2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
+  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.2, braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
@@ -1573,12 +2019,25 @@ browserslist@^4.23.1, browserslist@^4.23.3:
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.0"
 
+buffer-equal-constant-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
 busboy@1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz"
   integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
   dependencies:
     streamsearch "^1.1.0"
+
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
 
 call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6, call-bind@^1.0.7:
   version "1.0.7"
@@ -1719,6 +2178,13 @@ colorette@^2.0.20:
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@11.0.0:
   version "11.0.0"
   resolved "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz"
@@ -1762,6 +2228,15 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz"
@@ -1787,6 +2262,11 @@ csstype@^3.0.2:
   version "3.1.3"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
 data-view-buffer@^1.0.1:
   version "1.0.1"
@@ -1852,6 +2332,11 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 detect-libc@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz"
@@ -1878,10 +2363,36 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
+duplexify@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.3.tgz#a07e1c0d0a2c001158563d32592ba58bddb0236f"
+  integrity sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==
+  dependencies:
+    end-of-stream "^1.4.1"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+    stream-shift "^1.0.2"
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.5.4:
   version "1.5.13"
@@ -1897,6 +2408,13 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+end-of-stream@^1.4.1:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
+  integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
+  dependencies:
+    once "^1.4.0"
 
 es-abstract@^1.17.5, es-abstract@^1.22.1, es-abstract@^1.22.3, es-abstract@^1.23.0, es-abstract@^1.23.1, es-abstract@^1.23.2, es-abstract@^1.23.3:
   version "1.23.3"
@@ -1957,6 +2475,11 @@ es-define-property@^1.0.0:
   dependencies:
     get-intrinsic "^1.2.4"
 
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
 es-errors@^1.2.1, es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz"
@@ -1989,6 +2512,13 @@ es-object-atoms@^1.0.0:
   dependencies:
     es-errors "^1.3.0"
 
+es-object-atoms@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
+  dependencies:
+    es-errors "^1.3.0"
+
 es-set-tostringtag@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz"
@@ -1997,6 +2527,16 @@ es-set-tostringtag@^2.0.3:
     get-intrinsic "^1.2.4"
     has-tostringtag "^1.0.2"
     hasown "^2.0.1"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 es-shim-unscopables@^1.0.0, es-shim-unscopables@^1.0.2:
   version "1.0.2"
@@ -2013,6 +2553,38 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+esbuild@~0.28.0:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.1.tgz#ef45b4634c9c9d97a296aea4114a5f9840f95578"
+  integrity sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.1"
+    "@esbuild/android-arm" "0.28.1"
+    "@esbuild/android-arm64" "0.28.1"
+    "@esbuild/android-x64" "0.28.1"
+    "@esbuild/darwin-arm64" "0.28.1"
+    "@esbuild/darwin-x64" "0.28.1"
+    "@esbuild/freebsd-arm64" "0.28.1"
+    "@esbuild/freebsd-x64" "0.28.1"
+    "@esbuild/linux-arm" "0.28.1"
+    "@esbuild/linux-arm64" "0.28.1"
+    "@esbuild/linux-ia32" "0.28.1"
+    "@esbuild/linux-loong64" "0.28.1"
+    "@esbuild/linux-mips64el" "0.28.1"
+    "@esbuild/linux-ppc64" "0.28.1"
+    "@esbuild/linux-riscv64" "0.28.1"
+    "@esbuild/linux-s390x" "0.28.1"
+    "@esbuild/linux-x64" "0.28.1"
+    "@esbuild/netbsd-arm64" "0.28.1"
+    "@esbuild/netbsd-x64" "0.28.1"
+    "@esbuild/openbsd-arm64" "0.28.1"
+    "@esbuild/openbsd-x64" "0.28.1"
+    "@esbuild/openharmony-arm64" "0.28.1"
+    "@esbuild/sunos-x64" "0.28.1"
+    "@esbuild/win32-arm64" "0.28.1"
+    "@esbuild/win32-ia32" "0.28.1"
+    "@esbuild/win32-x64" "0.28.1"
 
 escalade@^3.1.1, escalade@^3.1.2:
   version "3.2.0"
@@ -2171,6 +2743,11 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 eventemitter3@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz"
@@ -2190,6 +2767,16 @@ execa@7.2.0:
     onetime "^6.0.0"
     signal-exit "^3.0.7"
     strip-final-newline "^3.0.0"
+
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+farmhash-modern@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/farmhash-modern/-/farmhash-modern-1.1.0.tgz#c36b34ad196290d57b0b482dc89e637d0b59835f"
+  integrity sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -2217,6 +2804,26 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-xml-builder@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz#abd2363145a7625d9789ad96da375fabe3cff28c"
+  integrity sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==
+  dependencies:
+    path-expression-matcher "^1.5.0"
+    xml-naming "^0.1.0"
+
+fast-xml-parser@^5.3.4:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz#9db7a6dba7ac6f8dc1ee924d69547b2d4750d60c"
+  integrity sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==
+  dependencies:
+    "@nodable/entities" "^2.2.0"
+    fast-xml-builder "^1.2.0"
+    is-unsafe "^1.0.1"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.4.1"
+    xml-naming "^0.1.0"
+
 fastq@^1.6.0:
   version "1.17.1"
   resolved "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz"
@@ -2230,6 +2837,14 @@ faye-websocket@0.11.4:
   integrity sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==
   dependencies:
     websocket-driver ">=0.5.1"
+
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -2252,6 +2867,23 @@ find-up@^5.0.0:
   dependencies:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
+
+firebase-admin@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-14.1.0.tgz#edc206d93fe1ba1949e3405e0704820f8a5dfc6b"
+  integrity sha512-GdHh6vHWm9LVRt+3hINWczaA7fPwnN/l4xZdqzn+wNPYErrLI1x6u1mvAJM/5IGgYI9EqQgLt1EyBG8ok/hWCg==
+  dependencies:
+    "@fastify/busboy" "^3.0.0"
+    "@firebase/database-compat" "^2.1.4"
+    "@firebase/database-types" "^1.0.20"
+    farmhash-modern "^1.1.0"
+    fast-deep-equal "^3.1.1"
+    google-auth-library "^10.6.2"
+    jsonwebtoken "^9.0.0"
+    jwks-rsa "^4.0.1"
+  optionalDependencies:
+    "@google-cloud/firestore" "^8.6.0"
+    "@google-cloud/storage" "^7.19.0"
 
 firebase@^9.17.1:
   version "9.23.0"
@@ -2306,12 +2938,63 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
+form-data-encoder@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
+  integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
+
+form-data@^2.5.5:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.6.tgz#ef39b3d99e2fc9f25420c0db7962fe36cafcd244"
+  integrity sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
+    safe-buffer "^5.2.1"
+
+form-data@^4.0.4:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
+
+formdata-node@^4.3.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/formdata-node/-/formdata-node-4.4.1.tgz#23f6a5cb9cb55315912cbec4ff7b0f59bbd191e2"
+  integrity sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==
+  dependencies:
+    node-domexception "1.0.0"
+    web-streams-polyfill "4.0.0-beta.3"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
+fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -2331,10 +3014,72 @@ function.prototype.name@^1.1.6:
     es-abstract "^1.22.1"
     functions-have-names "^1.2.3"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
+
 functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+gaxios@7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.3.tgz#c5312f4254abc1b8ab53aef30c22c5229b80b1e1"
+  integrity sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+    rimraf "^5.0.1"
+
+gaxios@^6.0.0, gaxios@^6.0.2, gaxios@^6.1.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-6.7.1.tgz#ebd9f7093ede3ba502685e73390248bb5b7f71fb"
+  integrity sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    is-stream "^2.0.0"
+    node-fetch "^2.6.9"
+    uuid "^9.0.1"
+
+gaxios@^7.0.0, gaxios@^7.1.4:
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.5.tgz#fd9c21e896f27794d0483e0f129a238145d7fdf2"
+  integrity sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+
+gcp-metadata@8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz#e62e3373ddf41fc727ccc31c55c687b798bee898"
+  integrity sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==
+  dependencies:
+    gaxios "^7.0.0"
+    google-logging-utils "^1.0.0"
+    json-bigint "^1.0.0"
+
+gcp-metadata@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-6.1.1.tgz#f65aa69f546bc56e116061d137d3f5f90bdec494"
+  integrity sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==
+  dependencies:
+    gaxios "^6.1.1"
+    google-logging-utils "^0.0.2"
+    json-bigint "^1.0.0"
+
+gcp-metadata@^8.0.0:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.3.tgz#60c6744240dbe5fbde30112b9d9aaa25ee611eb1"
+  integrity sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==
+  dependencies:
+    gaxios "7.1.3"
+    google-logging-utils "1.1.3"
+    json-bigint "^1.0.0"
 
 get-caller-file@^2.0.5:
   version "2.0.5"
@@ -2351,6 +3096,30 @@ get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
     hasown "^2.0.0"
+
+get-intrinsic@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 get-stream@^6.0.1:
   version "6.0.1"
@@ -2391,6 +3160,18 @@ glob@7.1.7:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^10.3.7:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
 
 glob@^7.1.3:
   version "7.2.3"
@@ -2447,12 +3228,86 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+google-auth-library@10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.5.0.tgz#3f0ebd47173496b91d2868f572bb8a8180c4b561"
+  integrity sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^7.0.0"
+    gcp-metadata "^8.0.0"
+    google-logging-utils "^1.0.0"
+    gtoken "^8.0.0"
+    jws "^4.0.0"
+
+google-auth-library@^10.6.2:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.9.0.tgz#61e742af957818f572c3a5bce634c68355241d64"
+  integrity sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^7.1.4"
+    gcp-metadata "8.1.2"
+    google-logging-utils "1.1.3"
+    jws "^4.0.0"
+
+google-auth-library@^9.6.3:
+  version "9.15.1"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-9.15.1.tgz#0c5d84ed1890b2375f1cd74f03ac7b806b392928"
+  integrity sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^6.1.1"
+    gcp-metadata "^6.1.0"
+    gtoken "^7.0.0"
+    jws "^4.0.0"
+
+google-gax@^5.0.1:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-5.0.7.tgz#306132df351163abfbfd3cccee3494001eb6bd8b"
+  integrity sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==
+  dependencies:
+    "@grpc/grpc-js" "^1.12.6"
+    "@grpc/proto-loader" "^0.8.0"
+    duplexify "^4.1.3"
+    google-auth-library "10.5.0"
+    google-logging-utils "1.1.3"
+    node-fetch "^3.3.2"
+    object-hash "^3.0.0"
+    proto3-json-serializer "3.0.4"
+    protobufjs "^7.5.4"
+    retry-request "^8.0.2"
+    rimraf "^5.0.1"
+
+google-logging-utils@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
+
+google-logging-utils@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-0.0.2.tgz#5fd837e06fa334da450433b9e3e1870c1594466a"
+  integrity sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==
+
+google-logging-utils@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.4.tgz#279c0f58efda53880e9bf0dda8b6d32789c570f9"
+  integrity sha512-LXxE6ND+JHhDPYtPFt3oeWrjxFPrnRZCZ4At6lpbi1ZDSAN7bmGET9s53vvARbxT93p+xpeDUbc/nCR4C+7vcw==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz"
   integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
   dependencies:
     get-intrinsic "^1.1.3"
+
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
 graceful-fs@^4.2.11:
   version "4.2.11"
@@ -2463,6 +3318,22 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+gtoken@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-7.1.0.tgz#d61b4ebd10132222817f7222b1e6064bd463fc26"
+  integrity sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==
+  dependencies:
+    gaxios "^6.0.0"
+    jws "^4.0.0"
+
+gtoken@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-8.0.0.tgz#d67a0e346dd441bfb54ad14040ddc3b632886575"
+  integrity sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==
+  dependencies:
+    gaxios "^7.0.0"
+    jws "^4.0.0"
 
 hamt_plus@1.0.2:
   version "1.0.2"
@@ -2501,6 +3372,11 @@ has-symbols@^1.0.2, has-symbols@^1.0.3:
   resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
+has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
 has-tostringtag@^1.0.0, has-tostringtag@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz"
@@ -2515,12 +3391,24 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
+
 hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"
+
+html-entities@^2.5.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.6.0.tgz#7c64f1ea3b36818ccae3d3fb48b6974208e984f8"
+  integrity sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==
 
 html-parse-stringify@^3.0.1:
   version "3.0.1"
@@ -2534,6 +3422,23 @@ http-parser-js@>=0.5.1:
   resolved "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz"
   integrity sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==
 
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
+http-proxy-agent@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
 https-proxy-agent@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz"
@@ -2542,10 +3447,25 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+https-proxy-agent@^7.0.1:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
 human-signals@^4.3.0:
   version "4.3.1"
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz"
   integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
+  dependencies:
+    ms "^2.0.0"
 
 husky@^8.0.3:
   version "8.0.3"
@@ -2619,7 +3539,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2784,6 +3704,11 @@ is-shared-array-buffer@^1.0.2, is-shared-array-buffer@^1.0.3:
   dependencies:
     call-bind "^1.0.7"
 
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
 is-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz"
@@ -2809,6 +3734,11 @@ is-typed-array@^1.1.13:
   integrity sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==
   dependencies:
     which-typed-array "^1.1.14"
+
+is-unsafe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-1.0.1.tgz#ce89b55dec0034364f5beda41e10481efa8fa317"
+  integrity sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==
 
 is-weakmap@^2.0.2:
   version "2.0.2"
@@ -2851,6 +3781,20 @@ iterator.prototype@^1.1.2:
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
 
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
+jose@^6.1.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.3.tgz#0975197ad973251221c658a3cddc4b951a250c2d"
+  integrity sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==
+
 js-md5@^0.8.3:
   version "0.8.3"
   resolved "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz"
@@ -2873,6 +3817,13 @@ jsesc@^2.5.1:
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
+
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz"
@@ -2888,6 +3839,22 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+jsonwebtoken@^9.0.0:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz#6cd57ab01e9b0ac07cb847d53d3c9b6ee31f7ae2"
+  integrity sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==
+  dependencies:
+    jws "^4.0.1"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^7.5.4"
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"
   resolved "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz"
@@ -2897,6 +3864,35 @@ json-stable-stringify-without-jsonify@^1.0.1:
     array.prototype.flat "^1.3.1"
     object.assign "^4.1.4"
     object.values "^1.1.6"
+
+jwa@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.1.tgz#bf8176d1ad0cd72e0f3f58338595a13e110bc804"
+  integrity sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==
+  dependencies:
+    buffer-equal-constant-time "^1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jwks-rsa@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/jwks-rsa/-/jwks-rsa-4.1.0.tgz#aaa2b33c2074c13ea7cc3edc64cc77881d85b686"
+  integrity sha512-sbkByqyATKYJP5F4RXj03N5TUNC0QLTjCAZvwTzC4BwJZ8e0/cWxN8YROnyUth2g1/ONWi4eSFHeu6oYalrc3Q==
+  dependencies:
+    "@types/jsonwebtoken" "^9.0.4"
+    debug "^4.3.4"
+    jose "^6.1.3"
+    limiter "^1.1.5"
+    lru-cache "^11.0.0"
+    lru-memoizer "^3.0.0"
+
+jws@^4.0.0, jws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.1.tgz#07edc1be8fac20e677b283ece261498bd38f0690"
+  integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
+  dependencies:
+    jwa "^2.0.1"
+    safe-buffer "^5.0.1"
 
 keyv@^4.5.3:
   version "4.5.4"
@@ -2924,6 +3920,11 @@ lilconfig@2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz"
   integrity sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==
+
+limiter@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.5.tgz#8f92a25b3b16c6131293a0cc834b4a838a2aa7c2"
+  integrity sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==
 
 lint-staged@^13.2.2:
   version "13.3.0"
@@ -2972,15 +3973,55 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.debounce@4.0.8, lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash@^4.17.21:
   version "4.17.21"
@@ -3008,12 +4049,27 @@ long@^5.0.0:
   resolved "https://registry.npmjs.org/long/-/long-5.2.3.tgz"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
+long@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
+lru-cache@^11.0.0, lru-cache@^11.0.1:
+  version "11.5.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.5.1.tgz#f3daa3540847b9737ebc02499ddb36765e54db4a"
+  integrity sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -3022,12 +4078,25 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-memoizer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-3.0.0.tgz#b75907de33ae84d4aa318c3083b9a774c7e5e767"
+  integrity sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==
+  dependencies:
+    lodash.clonedeep "^4.5.0"
+    lru-cache "^11.0.1"
+
 magic-string@^0.27.0:
   version "0.27.0"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz"
   integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.13"
+
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -3055,6 +4124,23 @@ micromatch@^4.0.4:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
@@ -3079,10 +4165,22 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
 minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 mkdirp@^0.5.5:
   version "0.5.6"
@@ -3095,6 +4193,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.0.0, ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 nanoid@^3.3.6:
   version "3.3.7"
@@ -3145,6 +4248,11 @@ next@^14.2.4:
     "@next/swc-win32-ia32-msvc" "14.2.7"
     "@next/swc-win32-x64-msvc" "14.2.7"
 
+node-domexception@1.0.0, node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@2.6.7, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
@@ -3152,12 +4260,21 @@ node-fetch@2.6.7, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.6.12:
+node-fetch@^2.6.12, node-fetch@^2.6.9:
   version "2.7.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-releases@^2.0.18:
   version "2.0.18"
@@ -3175,6 +4292,11 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
+object-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
+  integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
 object-inspect@^1.13.1:
   version "1.13.2"
@@ -3229,7 +4351,7 @@ on-change@^4.0.0:
   resolved "https://registry.npmjs.org/on-change/-/on-change-4.0.2.tgz"
   integrity sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -3250,6 +4372,19 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
+openai@^4.60.0:
+  version "4.104.0"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-4.104.0.tgz#c489765dc051b95019845dab64b0e5207cae4d30"
+  integrity sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==
+  dependencies:
+    "@types/node" "^18.11.18"
+    "@types/node-fetch" "^2.6.4"
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.2.1"
+    form-data-encoder "1.7.2"
+    formdata-node "^4.3.2"
+    node-fetch "^2.6.7"
+
 optionator@^0.9.3:
   version "0.9.4"
   resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz"
@@ -3262,7 +4397,7 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
-p-limit@^3.0.2:
+p-limit@^3.0.1, p-limit@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -3276,6 +4411,11 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
@@ -3287,6 +4427,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-expression-matcher@^1.5.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz#fb190513954875d7e1b05c8caabe7fdd0a4cd75b"
+  integrity sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -3307,6 +4452,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -3366,6 +4519,13 @@ prop-types@^15.7.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+proto3-json-serializer@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz#e8065316901d94cb5a08733855ed279ade84c72c"
+  integrity sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==
+  dependencies:
+    protobufjs "^7.4.0"
+
 protobufjs@^6.11.3:
   version "6.11.4"
   resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz"
@@ -3402,6 +4562,23 @@ protobufjs@^7.2.5:
     "@protobufjs/utf8" "^1.1.0"
     "@types/node" ">=13.7.0"
     long "^5.0.0"
+
+protobufjs@^7.4.0, protobufjs@^7.5.3, protobufjs@^7.5.4, protobufjs@^7.5.5:
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.4.tgz#8bb000300026efd63eb7951d26e5dbb38f5658f2"
+  integrity sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
+    "@types/node" ">=13.7.0"
+    long "^5.3.2"
 
 proxy-from-env@^1.1.0:
   version "1.1.0"
@@ -3466,6 +4643,15 @@ react@^18.2.0:
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
+
+readable-stream@^3.1.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 recoil@^0.7.6:
   version "0.7.7"
@@ -3538,6 +4724,28 @@ restore-cursor@^4.0.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+retry-request@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-7.0.2.tgz#60bf48cfb424ec01b03fca6665dee91d06dd95f3"
+  integrity sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==
+  dependencies:
+    "@types/request" "^2.48.8"
+    extend "^3.0.2"
+    teeny-request "^9.0.0"
+
+retry-request@^8.0.2:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-8.0.3.tgz#2ca7268be447cc8ffb199b653161faeae0d497b7"
+  integrity sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==
+  dependencies:
+    extend "^3.0.2"
+    teeny-request "^10.0.0"
+
+retry@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
@@ -3554,6 +4762,13 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@^5.0.1:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.10.tgz#23b9843d3dc92db71f96e1a2ce92e39fd2a8221c"
+  integrity sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==
+  dependencies:
+    glob "^10.3.7"
 
 rollup@2.78.0:
   version "2.78.0"
@@ -3579,7 +4794,7 @@ safe-array-concat@^1.1.2:
     has-symbols "^1.0.3"
     isarray "^2.0.5"
 
-safe-buffer@>=5.1.0:
+safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3614,6 +4829,11 @@ semver@^7.3.7, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+
+semver@^7.5.4:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 set-function-length@^1.2.1:
   version "1.2.2"
@@ -3698,6 +4918,11 @@ signal-exit@^3.0.2, signal-exit@^3.0.7:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz"
@@ -3730,6 +4955,18 @@ stacktrace-parser@^0.1.10:
   dependencies:
     type-fest "^0.7.1"
 
+stream-events@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/stream-events/-/stream-events-1.0.5.tgz#bbc898ec4df33a4902d892333d47da9bf1c406d5"
+  integrity sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==
+  dependencies:
+    stubs "^3.0.0"
+
+stream-shift@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.3.tgz#85b8fab4d71010fc3ba8772e8046cc49b8a3864b"
+  integrity sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==
+
 streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
@@ -3740,6 +4977,15 @@ string-argv@0.3.2:
   resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
@@ -3749,7 +4995,7 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^5.0.0, string-width@^5.0.1:
+string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
@@ -3812,6 +5058,20 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
@@ -3835,6 +5095,18 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strnum@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.1.tgz#85417f683113badea0fe7e17227676f889ff7e58"
+  integrity sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==
+  dependencies:
+    anynum "^1.0.1"
+
+stubs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
+  integrity sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==
 
 styled-components@^5, styled-components@^5.3.6:
   version "5.3.11"
@@ -3882,6 +5154,27 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+teeny-request@^10.0.0:
+  version "10.1.3"
+  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.3.tgz#f623c31ca503fac7388355c85230a22173894bd9"
+  integrity sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==
+  dependencies:
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+    stream-events "^1.0.5"
+
+teeny-request@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-9.0.0.tgz#18140de2eb6595771b1b02203312dfad79a4716d"
+  integrity sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==
+  dependencies:
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.9"
+    stream-events "^1.0.5"
+    uuid "^9.0.0"
 
 text-segmentation@^1.0.3:
   version "1.0.3"
@@ -3938,6 +5231,15 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+tsx@^4.22.4:
+  version "4.22.4"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.22.4.tgz#0ab3b7fb4ec7feeee74e5b1f26337caa71e44700"
+  integrity sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==
+  dependencies:
+    esbuild "~0.28.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -4025,10 +5327,20 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
 undici-types@~6.19.2:
   version "6.19.8"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+
+undici-types@~8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
+  integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
 update-browserslist-db@^1.1.0:
   version "1.1.0"
@@ -4045,6 +5357,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
 utrie@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz"
@@ -4052,10 +5369,25 @@ utrie@^1.0.2:
   dependencies:
     base64-arraybuffer "^1.0.2"
 
+uuid@^9.0.0, uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 void-elements@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz"
   integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
+
+web-streams-polyfill@4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz#2898486b74f5156095e473efe989dcf185047a38"
+  integrity sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==
+
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
@@ -4151,6 +5483,15 @@ word-wrap@^1.2.5:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
@@ -4173,6 +5514,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+xml-naming@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.1.0.tgz#8ab7106c5b8d23caa2fabac1cadf17136379fbd8"
+  integrity sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==
 
 y18n@^5.0.5:
   version "5.0.8"
@@ -4229,3 +5575,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Summary

- develop 에 머지된 AI 색상 추천 기능(#294)을 프로덕션에 배포
- **초기 배포는 기능 OFF 상태**로 진행 — 워크플로우 기본값 `NEXT_PUBLIC_ENABLE_AI_RECOMMEND='false'`
- 코드는 배포되지만 유저에게는 아직 노출 안 됨 (버튼 미렌더 + API 404)

## 포함된 변경

- feat: AI 색상 추천 기능 (BasicStage + BonusStage, GPT-4o mini/full 하이브리드) — #294

## ⚠ 병합 전 필수 확인

- [x] **GitHub Secrets 등록**: Settings → Secrets → Actions → `OPENAI_API_KEY` (새로 발급한 restricted 키)
- [x] **GitHub Variables 등록**: Settings → Variables → Actions → `ENABLE_AI_RECOMMEND` = `'false'` (초기)
- [x] **OpenAI 대시보드**: monthly hard limit $30 설정
- [x] **개인정보처리방침**: (앱 내 처리 방침 페이지 부재 시) 최소한 shareModal-스타일 consent 모달만으로 커버 중임을 인지. 정식 privacy 페이지는 후속 이슈

## 병합 후 동작

1. `production` 브랜치에 push → GitHub Actions `Deploy to Firebase Hosting on merge` 자동 실행
2. `.env` 조립 시 `NEXT_PUBLIC_ENABLE_AI_RECOMMEND=false` 로 빌드됨
3. Firebase Hosting 배포 완료 → 실제 서비스 유저는 AI 버튼 못 봄
4. Server 측 `/api/ai-recommend` 는 404 반환

## 기능 ON 절차 (후속)

프로덕션 안정성 확인 + 사전 세팅 완료 후:
1. GitHub Variables → `ENABLE_AI_RECOMMEND` = `'true'` 로 변경
2. Actions 탭 → 워크플로우 수동 재실행 (또는 production 에 자잘한 커밋 push)
3. 배포 완료 시점부터 실 유저에게 AI 버튼 노출 시작
4. Sentry / OpenAI 대시보드로 초기 요청 트래픽·에러율·비용 관찰
5. 이상 시 즉시 `ENABLE_AI_RECOMMEND='false'` 재배포로 롤백

## 관찰 지표 (Phase 4)

배포 후 첫 1주간 모니터링:
- 총 API 요청 수 vs 예산 소진율
- 폴백률(mini → full): 20% 이상이면 프롬프트 재검토
- confidence 히스토그램: 0.7 임계값 재조정 근거 수집
- 유저 편향 피드백: 다양한 피부톤에서의 정확도

## Test plan

- [x] develop 브랜치 CI 통과 (lint + build)
- [x] 로컬 dev 서버에서 종단 흐름 검증 (여름 라이트 도달)
- [x] BonusStage 통합 검증
- [x] Consent 모달 노출·저장 검증
- [ ] 프로덕션 배포 직후 랜딩 → 컬러 진단 흐름 정상 동작 (기능 OFF 상태에서도 회귀 없음) 확인
- [ ] `curl -I https://oppamanycolortone.com/api/ai-recommend -X POST` → 404 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)