### PR TITLE
fix(deploy): prepare 스크립트가 devDep 없어도 실패하지 않도록

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "prepare": "husky install",
+    "prepare": "husky install || true",
     "lint": "next lint",
     "lint-staged": "lint-staged",
     "lint-fix": "eslint '**/*.{tsx,ts}' --ext .ts,.tsx --fix",


### PR DESCRIPTION
## Summary

프로덕션 배포가 2번 연속(#295, #297) 실패한 진짜 원인을 발견하고 수정.

## 원인

firebase-tools 의 \`prepareFrameworks\` 단계에서 실행되는 \`npm i --omit=dev --no-audit\` 이 exit code 127 로 실패.

로컬 재현 결과:
\`\`\`
> oppamanycolortone@0.0.0 prepare
> husky install
sh: husky: command not found
npm error code 127
\`\`\`

- \`prepare\` lifecycle 이 \`husky install\` 을 호출
- \`--omit=dev\` 로 husky (devDependency) 가 설치 안 된 상태에서 실행
- \`sh: husky: command not found\` (exit 127) 발생 → npm i 전체 실패

이전 시도(#296) 의 firebase-admin@14→13 다운그레이드는 무관한 수정이었음
(배포 로그가 잘려 husky 이슈가 아닌 firebase-admin engine 경고로 오인).

## 수정

\`\`\`diff
- "prepare": "husky install",
+ "prepare": "husky install || true",
\`\`\`

- 로컬 dev 환경(husky 존재)에선 git hooks 정상 설치
- 프로덕션 배포 컨텍스트(devDep 제외)에선 무해하게 통과

## 로컬 검증

\`\`\`
BEFORE: sh: husky: command not found / npm error code 127
AFTER:  added 458 packages in 8s (exit 0)
\`\`\`

## 병합 순서

1. **이 PR 을 develop 에 병합**
2. #297 (develop → production) 자동으로 최신 develop 반영 → 배포 재시도 → 정상 통과 예상

## Test plan

- [x] 로컬 임시 dir 에서 \`npm i --omit=dev --no-audit\` 재현·검증
- [x] 로컬 dev 환경 husky 훅은 여전히 정상 동작 (기존 lint-staged 커밋 hook 확인)
- [ ] develop 병합 후 production 배포 재시도 → \`prepareFrameworks\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)