### PR TITLE
release: 배포 husky prepare 이슈 수정 반영

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "prepare": "husky install",
+    "prepare": "husky install || true",
     "lint": "next lint",
     "lint-staged": "lint-staged",
     "lint-fix": "eslint '**/*.{tsx,ts}' --ext .ts,.tsx --fix",


### PR DESCRIPTION
## Summary

이전 두 차례 배포(#295, #297) 가 firebase-tools `prepareFrameworks` 단계에서 실패한 진짜 원인을 잡고 재배포.

## 포함된 변경

- fix(deploy): prepare 스크립트가 devDep 없어도 실패하지 않도록 (#298)

## 원인 확정 로그

로컬에서 동일 명령 재현:

```
> oppamanycolortone@0.0.0 prepare
> husky install
sh: husky: command not found
npm error code 127
```

- firebase-tools 는 `npm i --omit=dev --no-audit` 로 프로덕션 의존성만 설치
- 이때 husky (devDep) 는 skip 되지만 `prepare` 라이프사이클이 여전히 실행
- `sh: husky: command not found` → exit 127 → 전체 실패

## 수정

`package.json` 한 줄:
```diff
- "prepare": "husky install",
+ "prepare": "husky install || true",
```

- 로컬 dev 환경: husky 정상 설치·git hooks 동작 유지
- 배포 환경: husky 없을 때 무해하게 통과

## 배포 후 예상 동작

- `NEXT_PUBLIC_ENABLE_AI_RECOMMEND` 는 여전히 `'false'` 로 배포
- AI 기능 코드는 실릴 뿐 유저에겐 노출 안 됨 (안전)
- `/api/ai-recommend` 는 404

## Test plan

- [x] 로컬 `npm i --omit=dev --no-audit` 재현·검증
- [x] husky git hooks 로컬 dev 환경 정상 동작
- [ ] production 배포 시 `prepareFrameworks` 통과
- [ ] 배포 완료 후 랜딩·컬러 진단 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)