### PR TITLE
fix(deploy): zod v4 → v3 (openai peer 충돌 해소, 배포 실패 진짜 원인)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "stylelint-config-prettier": "^9.0.5",
     "text-segmentation": "^1.0.3",
     "ua-parser-js": "^2.0.0-alpha.2",
-    "zod": "^4.4.3"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^13.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5398,7 +5398,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
-  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
+zod@^3.23.8:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==


### PR DESCRIPTION
## Summary

프로덕션 배포가 3번 연속 실패한 진짜 원인 확정 및 수정.

## 원인 (드디어 확보한 완전한 로그)

\`\`\`
npm error code ERESOLVE
npm error While resolving: openai@4.104.0
npm error Found: zod@4.4.3
npm error Could not resolve dependency:
npm error peerOptional zod@"^3.23.8" from openai@4.104.0
npm error Conflicting peer dependency: zod@3.25.76
\`\`\`

- yarn 은 permissive 하여 로컬/CI 빌드는 통과
- firebase-tools 의 \`prepareFrameworks\` 가 실행하는 \`npm i --omit dev\` 는 npm 7+ 의 strict peer 리졸버로 즉시 ERESOLVE 실패
- 12초만에 실패한 시간 패턴도 즉시 리졸버 에러와 일치

## 이전 두 시도가 무관했던 이유

배포 로그가 firebase-tools 의 \`prepareFrameworks\` 스택 위쪽에서 잘려있어 실제 npm error 가 안 보였음. 대신 \`⚠ This integration expects Node version 16, 18, or 20\` 경고만 보여서:

- #296: firebase-admin@14 → 13 다운그레이드 → 무관 (여전히 zod 이슈)
- #298: prepare husky || true → 무관 (여전히 zod 이슈)

두 수정 자체는 유효하지만 배포 실패의 원인은 아니었음.

## 이번 수정

\`\`\`diff
- "zod": "^4.4.3"
+ "zod": "^3.23.8"
\`\`\`

- openai@4.104.0 의 peerOptional \`zod@^3.23.8\` 과 매칭
- 이 프로젝트 Zod 사용 API 는 모두 v3/v4 동일 시그니처 (코드 변경 불필요)

## 로컬 검증

- \`yarn build\` 성공, 모든 라우트 정상 컴파일
- 임시 dir 에서 \`npm i --omit=dev --no-audit\` → 645 packages 정상 (ERESOLVE 없음)

## 병합 순서

1. **이 PR 을 develop 에 병합**
2. develop → production PR 새로 열어 재배포

## Test plan

- [x] 로컬 \`yarn build\` 성공
- [x] \`npm i --omit=dev --no-audit\` (firebase-tools 시뮬레이션) 성공
- [x] Zod schema 코드 v3/v4 호환 API 만 사용 확인
- [ ] production 배포 시 prepareFrameworks 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)