### PR TITLE
release: zod 다운그레이드로 배포 재시도 (진짜 원인 수정)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "stylelint-config-prettier": "^9.0.5",
     "text-segmentation": "^1.0.3",
     "ua-parser-js": "^2.0.0-alpha.2",
-    "zod": "^4.4.3"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^13.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5398,7 +5398,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
-  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
+zod@^3.23.8:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==


### PR DESCRIPTION
## Summary

세 번의 배포 실패 끝에 진짜 원인(zod v4 peer 충돌)을 확정하고 수정한 릴리즈.

## 포함된 변경

- fix(deploy): zod v4 → v3 (openai peer 충돌 해소) — #300

## 원인 요약

firebase-tools 의 `prepareFrameworks` 내부 `npm i --omit dev` 가 npm strict peer 리졸버로 즉시 ERESOLVE 실패:

```
peerOptional zod@"^3.23.8" from openai@4.104.0
Conflicting peer dependency: zod@3.25.76
```

이번 커밋에서 zod 를 `^3.23.8` 로 맞춰 해소.

## 배포 후 예상 동작

- `NEXT_PUBLIC_ENABLE_AI_RECOMMEND` 여전히 `'false'` (안전)
- AI 코드는 배포되지만 유저에겐 미노출
- `/api/ai-recommend` 는 404

## Test plan

- [x] 로컬 `yarn build` 성공
- [x] `npm i --omit=dev --no-audit` 시뮬레이션 성공
- [ ] production 배포 시 `prepareFrameworks` 통과
- [ ] 배포 완료 후 랜딩·컬러 진단 스모크 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)