### PR TITLE
release: 프로덕션 500 핫픽스 (next-i18next config 트레이싱)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,6 +23,11 @@ const nextConfig = {
     ],
   },
   i18n,
+  experimental: {
+    outputFileTracingIncludes: {
+      '/**/*': ['./next-i18next.config.js', './public/locales/**/*'],
+    },
+  },
 };
 
 const sentryWebpackPluginOptions = {


### PR DESCRIPTION
## Summary

프로덕션에서 SSR 페이지 500 을 대량 유발하던 버그 핫픽스 배포.

## 포함된 변경

- fix(deploy): next-i18next.config.js 를 outputFileTracing 에 포함 (#302)

## 원인 요약

Cloud Run stderr:
```
Error: next-i18next was unable to find a user config
at /workspace/next-i18next.config.js
```

firebase-tools 의 packaging 이 next-i18next.config.js 를 배포 이미지에 포함시키지 않아 SSR 시 runtime 에러. `outputFileTracingIncludes` 로 명시 포함하도록 수정.

## 배포 후 확인

1. Actions → **Deploy to Firebase Hosting on merge** 실행 로그
2. 배포 완료 후 즉시:
   ```
   curl -I https://oppamanycolortone.com/
   curl -I https://oppamanycolortone.com/ko/result?colorType=autumndeep
   ```
   두 URL 모두 200 이어야 함
3. Cloud Run stderr 에서 `next-i18next was unable to find a user config` 에러가 사라지는지 확인

## 상태

- `NEXT_PUBLIC_ENABLE_AI_RECOMMEND` 여전히 `'false'` (안전)
- AI 코드는 있지만 유저에겐 미노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)