### PR TITLE
fix(deploy): serverSideTranslations 에 config 명시 전달 (@Root 별칭)

### DIFF
--- a/src/pages/all-types-view/index.page.tsx
+++ b/src/pages/all-types-view/index.page.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'next-i18next';
 
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
@@ -128,7 +129,7 @@ const AllTypesView = () => {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/src/pages/choice-color/index.page.tsx
+++ b/src/pages/choice-color/index.page.tsx
@@ -16,6 +16,7 @@ import { withLoadingRouter } from '@Components/WithLoadingRouter/withLoadingRout
 import { OnboardingPage } from '@Pages/choice-color/subpages/onboadring.subpage';
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 
 const Page = () => {
   const searchParams = useSearchParams();
@@ -113,7 +114,7 @@ function ChoiceColor() {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/src/pages/image-upload/index.page.tsx
+++ b/src/pages/image-upload/index.page.tsx
@@ -4,6 +4,7 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { useTranslation } from 'next-i18next';
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserPlus } from '@fortawesome/free-solid-svg-icons';
@@ -162,7 +163,7 @@ function ImageUploadPage() {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -5,6 +5,7 @@ import { type GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 import { useSetRecoilState } from 'recoil';
 import Spline from '@splinetool/react-spline';
 import { Application } from '@splinetool/runtime';
@@ -180,7 +181,7 @@ export default function Home() {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/src/pages/landing-temp/index.page.tsx
+++ b/src/pages/landing-temp/index.page.tsx
@@ -17,6 +17,7 @@ import * as S from './style';
 
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 import { cLocales } from '@Constant/locales';
 import { withDefault } from '@Base/utils/dataExtension';
 
@@ -124,7 +125,7 @@ function LandingPage() {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/src/pages/result/index.page.tsx
+++ b/src/pages/result/index.page.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'next-i18next';
 
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 
 import { createConsecutiveNumbers } from '@Base/utils/arrExtension';
 import useScrollTop from '@Base/hooks/useScrollTop';
@@ -153,7 +154,7 @@ function ResultPage(): JSX.Element {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
       "@Styles/*": ["./src/styles/*"],
       "@Utils/*": ["./src/utils/*"],
       "@Base/*": ["./base/*"],
+      "@Root/*": ["./*"],
       "public/*": ["./public/*"]
     },
     "allowJs": true,


### PR DESCRIPTION
## Summary

이전 fix(#302) 배포 후에도 프로덕션 SSR 500 재발. \`outputFileTracingIncludes\` 만으로는 next-i18next config 가 여전히 배포 컨테이너 \`/workspace/\` 에 안 들어감.

## Cloud Run stderr (동일 에러 재발)

\`\`\`
Error: next-i18next was unable to find a user config
at /workspace/next-i18next.config.js
\`\`\`

## 원인 확정

Firebase-tools 의 webframeworks packaging 이 Next.js output file tracing 결과를 완전히 존중하지 않아 tracing 힌트로는 config 파일을 배포 컨테이너에 포함 못 시킴.

## 이번 수정 (근본 해결)

각 페이지의 \`serverSideTranslations()\` 세 번째 인자로 config 를 명시 전달. config 가 코드에 import 되면 웹팩 번들에 함께 들어가서 런타임 fs 조회 자체가 불필요.

**경로 설계**: 프로젝트 컨벤션(깊은 상대경로 회피)에 맞춰 tsconfig 에 \`@Root/*\` 별칭 추가.

\`\`\`json
"@Root/*": ["./*"]
\`\`\`

\`\`\`ts
import nextI18NextConfig from '@Root/next-i18next.config';
// ...
await serverSideTranslations(locale, ['common'], nextI18NextConfig)
\`\`\`

## 수정된 페이지 (6개)

- \`src/pages/index.page.tsx\`
- \`src/pages/image-upload/index.page.tsx\`
- \`src/pages/result/index.page.tsx\`
- \`src/pages/all-types-view/index.page.tsx\`
- \`src/pages/landing-temp/index.page.tsx\`
- \`src/pages/choice-color/index.page.tsx\`

\`_app.page.tsx\` 는 이미 \`appWithTranslation(App, i18nextConfig)\` 로 config 를 전달하고 있어서 초기화는 문제없었음.

## 병합 순서

1. **이 PR 을 develop 에 병합**
2. develop → production PR 새로 열어 재배포
3. 배포 완료 후 랜딩·result 등 SSR 페이지 200 응답 확인

## Test plan

- [x] 로컬 \`yarn build\` 성공
- [ ] production 배포 시 stderr 에서 \`next-i18next was unable to find\` 에러 사라짐 확인
- [ ] \`curl -I https://oppamanycolortone.com/\` 200 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)