### PR TITLE
release: SSR 500 재수정 (config 명시 전달)

### DIFF
--- a/src/pages/all-types-view/index.page.tsx
+++ b/src/pages/all-types-view/index.page.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'next-i18next';
 
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
@@ -128,7 +129,7 @@ const AllTypesView = () => {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/src/pages/choice-color/index.page.tsx
+++ b/src/pages/choice-color/index.page.tsx
@@ -16,6 +16,7 @@ import { withLoadingRouter } from '@Components/WithLoadingRouter/withLoadingRout
 import { OnboardingPage } from '@Pages/choice-color/subpages/onboadring.subpage';
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 
 const Page = () => {
   const searchParams = useSearchParams();
@@ -113,7 +114,7 @@ function ChoiceColor() {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/src/pages/image-upload/index.page.tsx
+++ b/src/pages/image-upload/index.page.tsx
@@ -4,6 +4,7 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { useTranslation } from 'next-i18next';
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserPlus } from '@fortawesome/free-solid-svg-icons';
@@ -162,7 +163,7 @@ function ImageUploadPage() {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -5,6 +5,7 @@ import { type GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 import { useSetRecoilState } from 'recoil';
 import Spline from '@splinetool/react-spline';
 import { Application } from '@splinetool/runtime';
@@ -180,7 +181,7 @@ export default function Home() {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/src/pages/landing-temp/index.page.tsx
+++ b/src/pages/landing-temp/index.page.tsx
@@ -17,6 +17,7 @@ import * as S from './style';
 
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 import { cLocales } from '@Constant/locales';
 import { withDefault } from '@Base/utils/dataExtension';
 
@@ -124,7 +125,7 @@ function LandingPage() {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/src/pages/result/index.page.tsx
+++ b/src/pages/result/index.page.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'next-i18next';
 
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '@Root/next-i18next.config';
 
 import { createConsecutiveNumbers } from '@Base/utils/arrExtension';
 import useScrollTop from '@Base/hooks/useScrollTop';
@@ -153,7 +154,7 @@ function ResultPage(): JSX.Element {
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+      ...(await serverSideTranslations(locale ?? 'en', ['common'], nextI18NextConfig)),
     },
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
       "@Styles/*": ["./src/styles/*"],
       "@Utils/*": ["./src/utils/*"],
       "@Base/*": ["./base/*"],
+      "@Root/*": ["./*"],
       "public/*": ["./public/*"]
     },
     "allowJs": true,


### PR DESCRIPTION
## Summary

이전 릴리즈(#303) 배포 후에도 프로덕션 500 이 재발하여 근본 수정 반영.

## 포함된 변경

- fix(deploy): serverSideTranslations 에 config 명시 전달 (@Root 별칭) — #304

## 원인 및 해결

- 원인: firebase-tools packaging 이 Next.js output file tracing 을 완전히 존중하지 않아 `next-i18next.config.js` 가 `/workspace/` 에 미포함
- 해결: 각 페이지 `serverSideTranslations()` 세 번째 인자로 config 를 명시 전달 → 웹팩 번들에 포함되어 런타임 fs 조회 불필요
- 경로: `@Root/*` 별칭 신설로 깊은 상대경로 회피

## 배포 후 확인

```bash
curl -I https://oppamanycolortone.com/
curl -I https://oppamanycolortone.com/ko/result?colorType=autumndeep
curl -I https://oppamanycolortone.com/all-types-view
```

셋 다 **200** 이어야 함. Cloud Run stderr 에서 `next-i18next was unable to find a user config` 에러가 사라지는지도 확인.

## 상태

- `NEXT_PUBLIC_ENABLE_AI_RECOMMEND` 여전히 `'false'` (안전 유지)
- AI 코드는 있지만 유저 노출 미개시

🤖 Generated with [Claude Code](https://claude.com/claude-code)