### PR TITLE
release: 실패 시 quota refund + SESSION_MAX 10

### DIFF
--- a/src/pages/api/ai-recommend.page.ts
+++ b/src/pages/api/ai-recommend.page.ts
@@ -10,7 +10,7 @@ import {
   type AiRecommendErrorCode,
   type AiRecommendResponse,
 } from '@Utils/aiRecommend/schema';
-import { checkAndConsume } from '@Utils/aiRecommend/rateLimiter';
+import { checkAndConsume, refund } from '@Utils/aiRecommend/rateLimiter';
 
 export const config = {
   api: {
@@ -119,6 +119,12 @@ export default async function handler(
     };
     res.status(200).json(body);
   } catch (err) {
+    // 유저에게 결과를 주지 못한 실패는 quota 를 되돌려줘서 재시도 시
+    // 이중 차감되지 않도록 한다.
+    await refund(sessionId, ip).catch((refundErr) => {
+      // eslint-disable-next-line no-console
+      console.error('[ai-recommend] refund failed', refundErr);
+    });
     if (err instanceof AiRecommendServiceError) {
       if (err.code === 'NO_FACE_DETECTED') {
         respondError(res, 'NO_FACE_DETECTED', err.message);

--- a/src/utils/aiRecommend/rateLimiter.ts
+++ b/src/utils/aiRecommend/rateLimiter.ts
@@ -4,7 +4,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 
 import { getAdminDb } from './adminDb';
 
-export const SESSION_MAX = 9;
+export const SESSION_MAX = 10;
 export const IP_DAILY_MAX = 30;
 
 const COLLECTION = 'aiRecommendRateLimit';
@@ -120,5 +120,40 @@ export async function checkAndConsume(
       sessionRemaining: SESSION_MAX - (sessionCount + 1),
       ipRemaining: IP_DAILY_MAX - (ipCount + 1),
     };
+  });
+}
+
+export async function refund(sessionId: string, ip: string): Promise<void> {
+  if (LOCAL_IPS.has(ip)) return;
+
+  const db = getAdminDb();
+  const dayKey = todayKey();
+  const ipDocId = `ip_${hashIp(ip)}_${dayKey}`;
+  const sessionDocId = `session_${sessionId}`;
+
+  const ipRef = db.collection(COLLECTION).doc(ipDocId);
+  const sessionRef = db.collection(COLLECTION).doc(sessionDocId);
+
+  await db.runTransaction(async (tx) => {
+    const [ipSnap, sessionSnap] = await Promise.all([
+      tx.get(ipRef),
+      tx.get(sessionRef),
+    ]);
+
+    const sessionCount = (sessionSnap.data()?.count as number | undefined) ?? 0;
+    if (sessionSnap.exists && sessionCount > 0) {
+      tx.update(sessionRef, {
+        count: FieldValue.increment(-1),
+        lastAt: FieldValue.serverTimestamp(),
+      });
+    }
+
+    const ipCount = (ipSnap.data()?.count as number | undefined) ?? 0;
+    if (ipSnap.exists && ipCount > 0) {
+      tx.update(ipRef, {
+        count: FieldValue.increment(-1),
+        lastAt: FieldValue.serverTimestamp(),
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary

AI 추천 재시도 관련 UX 개선 배포.

## 포함된 변경

- fix(ai-recommend): 실패 시 quota refund (재시도 이중 차감 방지) — #306
- feat(ai-recommend): SESSION_MAX 9 → 10 (BonusStage 편입 반영) — #306 (같은 PR)

## 주요 동작 변경

1. **실패 시 refund**
   - AI 추천 요청이 실패(NO_FACE_DETECTED, AI_UNAVAILABLE 등)하면 세션/IP 카운터를 -1
   - 유저가 "다시 시도" 눌러도 총 1회로만 계산
   - 성공(200) 요청은 그대로 카운트

2. **SESSION_MAX 10 상향**
   - BasicStage 9문항 + BonusStage 1 = 10회로 조정
   - IP_DAILY_MAX(30) 은 유지

## 배포 후 확인

- `NEXT_PUBLIC_ENABLE_AI_RECOMMEND` 여전히 `'false'` — 유저 노출 없음
- Cloud Run stderr 에러 없어야 함
- 랜딩·result 정상 200

## Test plan

- [x] 로컬 build 통과
- [ ] 배포 후 랜딩/result 200 유지 확인
- [ ] `ENABLE_AI_RECOMMEND` 켠 후 (별도 절차) 재시도 시 usageRemaining 재차감 안 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)