### PR TITLE
docs+fix: AI 추천 문서 슬림화 + BonusStage 하이라이트 버그 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,55 @@ _오빠! 톤 많아? 퍼스널 컬러 자가진단_
 
 > Github 링크: https://github.com/SaekKkanDa/OppaManyColorTone
 
+## 🗺 서비스 흐름
+
+랜딩부터 결과 페이지까지의 전체 사용자 여정. 각 문항에서 AI 추천은 옵션이며 스킵 가능.
+
+```mermaid
+flowchart TD
+  Start([사용자 진입]) --> Landing["/ (랜딩)"]
+  Landing --> Upload["/image-upload<br/>사진 업로드 + 얼굴 감지 + 크롭"]
+  Upload --> Choice["/choice-color<br/>진단 시작"]
+
+  subgraph Basic["BasicStage — 9문항 반복"]
+    direction TB
+    BQ[문항 N/9<br/>4개 컬러 옵션 렌더]
+    BQ --> BAI{{✨ AI 추천 받기?}}
+    BAI -- 클릭 --> BAIFlow[[AI 추천]]
+    BAI -- 스킵 --> BPick[유저가 옵션 선택]
+    BAIFlow --> BHilite["추천 옵션 하이라이트<br/>+ 이유 배너"]
+    BHilite --> BPick
+    BPick --> BNext{다음 문항?}
+    BNext -- 예 --> BQ
+  end
+
+  Choice --> Basic
+  BNext -- 아니오<br/>(9문항 완료) --> Score[최빈값 스코어링<br/>+ 축별 tie-breaking]
+  Score --> Winner{승자 명확?}
+
+  Winner -- 아니오<br/>(동률·애매) --> Bonus
+  Winner -- 예 --> Result
+
+  subgraph Bonus["BonusStage — 정제"]
+    direction TB
+    BoQ["후보 타입 2~4개의<br/>대표 컬러 세트 표시"]
+    BoQ --> BoAI{{✨ AI 추천 받기?}}
+    BoAI -- 클릭 --> BoAIFlow[[AI 추천]]
+    BoAI -- 스킵 --> BoPick[유저가 타입 선택]
+    BoAIFlow --> BoHilite[하이라이트]
+    BoHilite --> BoPick
+  end
+
+  Bonus --> BoPick
+  BoPick --> Result[/"/result?colorType=X<br/>최종 결과 표시"/]
+  Result --> Share([공유·재시작])
+
+  style BAIFlow fill:#fce4ec
+  style BoAIFlow fill:#fce4ec
+```
+
+> AI 추천 세부 (프롬프트·모델 라우팅·레이트 리밋 등) 는 [docs/domain/ai-color-recommendation.md](./docs/domain/ai-color-recommendation.md) 참조.
+
 ## ✨ Installation
 
 ```bash

--- a/docs/domain/ai-color-recommendation.md
+++ b/docs/domain/ai-color-recommendation.md
@@ -1,666 +1,436 @@
-# AI 색상 추천 기능 설계 문서
+# AI 색상 추천 기능 문서
 
-> 메인 스테이지(9문항)에서 유저가 4개 컬러 옵션 사이에서 고민할 때, 선택적으로 **OpenAI GPT‑4o Vision** 기반 추천을 받아볼 수 있도록 하는 기능의 설계 문서.
+BasicStage(9문항) + BonusStage 에서 유저가 컬러 옵션 사이에서 고민할 때 선택적으로 **OpenAI GPT‑4o Vision** 기반 추천을 받을 수 있는 기능. **하이브리드 라우팅** (gpt-4o-mini 1차 + gpt-4o 폴백) 으로 비용·정확도 균형.
 
-- **작성일**: 2026-07-02
-- **모델**: OpenAI **GPT‑4o‑mini (1차) + GPT‑4o (폴백)** — 하이브리드 라우팅
-- **상태**: 설계 초안 (구현 착수 전 리뷰 필요)
+- **작성일**: 2026-07-02 (설계 초안)
+- **최종 업데이트**: 2026-07-03 (구현 완료 + 관찰 반영)
+- **상태**: 프로덕션 배포 완료, 기능 flag OFF 상태로 대기
 
----
-
-## 1. 목적 (Purpose)
-
-### 1.1 문제
-- 4개 컬러가 서로 유사할 때 유저가 고민하며 이탈하거나 무작위로 선택함
-- 사진 기반 정량적 판단이 부재 → 자가 진단의 신뢰도 낮음
-- 결과의 정확도가 유저 선택에만 의존
-
-### 1.2 목표
-- 유저가 원할 때만 표시되는 **비강제적 AI 조언** 제공
-- 기존 자가 진단 흐름을 방해하지 않음 (참고용, opt‑in)
-- 결과 신뢰도 향상 및 이탈률 감소
-
-### 1.3 비목표 (Non‑goals)
-- AI가 유저 선택을 대체하지 않음 (최종 선택은 언제나 유저)
-- AI 추천만으로 최종 컬러 타입을 결정하지 않음
-- 실시간 카메라 스트림 처리 (업로드된 이미지만 사용)
+> 서비스 전체 사용자 여정은 프로젝트 [README.md](../../README.md#-서비스-흐름) 참조. 이 문서는 AI 추천 기능만 다룸.
 
 ---
 
-## 2. 사용자 스토리 (User Story)
+## 0. 구현 상태 및 설계 대비 변경 사항
 
-```
-As 진단 중인 유저,
-When 문항의 4개 컬러 중 결정하기 어려울 때,
-I want "AI 추천 받기" 버튼을 눌러 참고 의견을 받고 싶다.
-So that 좀 더 확신을 갖고 선택할 수 있다.
-```
+### 0.1 현재 배포 상태
 
-**받아들임 기준 (Acceptance Criteria)**
-- 유저는 언제든 AI 추천 없이 진단 진행 가능
-- 첫 사용 시 데이터 전송에 대한 명시적 동의 필요
-- 추천 결과는 하이라이트 + 짧은 이유(1‑2문장) 형태
-- 문항당 1회 캐시됨 (재클릭 시 API 재호출 안 함)
-- 세션/IP별 사용 횟수 제한 존재
+| 항목 | 값 |
+| --- | --- |
+| 프로덕션 배포 | ✅ 완료 (production 브랜치) |
+| Feature flag | `NEXT_PUBLIC_ENABLE_AI_RECOMMEND='false'` (초기 OFF) |
+| 노출 범위 | BasicStage 9문항 + BonusStage 1문항 (세션당 총 10회 상한) |
+| ON 절차 | GitHub Variables → `ENABLE_AI_RECOMMEND='true'` → 재배포 |
+
+### 0.2 설계 대비 실제 구현 차이
+
+| 영역 | 설계 (v0) | 실제 구현 |
+| --- | --- | --- |
+| 레이트 리밋 스토리지 | RTDB | **Firestore + firebase-admin** (기존 `omctDb` 통일) |
+| API 라우트 경로 | `ai-recommend.ts` | **`ai-recommend.page.ts`** (`pageExtensions` 확장) |
+| 동의 절차 | 암묵 동의 | **명시적 동의 모달** (§4.2) |
+| 노출 문항 | BasicStage 9 | **BasicStage 9 + BonusStage 1** |
+| 옵션 스키마 | `{type, color, name}` | `{type, color, name?, season, tone}` |
+| 재현성 | `temperature: 0.3` | `temperature: 0`, `seed: 42` |
+| 실패 시 quota | 소진 | **refund 로 환원** |
+| 프롬프트 | 단순 지시 | **상대 비교 프레이밍 + 언더톤 방법론 + 웜 편향 보정 + 한국인 쿨 prior + tone 축 시각 특성** |
+| UI 라벨 | "AI 추천" | "이 4가지 중 AI 픽" |
+
+각 결정의 이유는 관련 절/PR 커밋 메시지 참조.
 
 ---
 
-## 3. 아키텍처 개요 (Architecture Overview)
+## 1. 아키텍처
 
-### 3.1 컴포넌트 다이어그램
+### 1.1 컴포넌트 다이어그램
 
 ```mermaid
 graph TB
-  subgraph Client["Client (Next.js Page Router)"]
-    UI[BasicStage UI]
-    AIB[AI 추천 버튼 컴포넌트]
-    Cache[Recoil: aiRecommendCache]
-    Consent[동의 모달]
+  subgraph Client["Client (Next.js Pages Router)"]
+    BS[BasicStage / BonusStage UI]
+    AIB[AiRecommendButton]
+    Modal[AiConsentModal 스낵바]
+    Hook[useAiRecommend 훅]
+    Cache["Recoil atoms<br/>cache / sessionId / usageRemaining / consent"]
+    Rsz[Canvas 800×800 리사이즈]
+    LS[(localStorage:<br/>aiRecommendConsent)]
   end
 
-  subgraph Server["Server (Next.js API Route on Firebase Functions)"]
-    API[/pages/api/ai-recommend]
-    RL[Rate Limiter]
-    OAI[OpenAI SDK Wrapper]
+  subgraph Server["Server (API on Firebase Cloud Functions)"]
+    API[/pages/api/ai-recommend.page.ts]
+    Sch[Zod 스키마 검증]
+    RL["rateLimiter.ts<br/>checkAndConsume / refund"]
+    OAI["openaiClient.ts<br/>하이브리드 라우팅"]
+    Admin[firebase-admin<br/>ADC 자동 인증]
   end
 
   subgraph External["External"]
-    OpenAI[OpenAI GPT-4o Vision API]
+    OpenAI[OpenAI Chat Completions Vision]
   end
 
-  subgraph Firebase["Firebase"]
-    RTDB[(Realtime DB)]
-    Secrets[(Functions Secret Manager)]
+  subgraph Firebase["Firebase 인프라"]
+    FS[(Firestore<br/>aiRecommendRateLimit)]
+    GH[(GitHub Secrets:<br/>OPENAI_API_KEY)]
   end
 
-  UI -- 사진, 4옵션 --> AIB
-  AIB -- POST --> API
-  API --> RL
-  RL --> RTDB
-  API --> OAI
-  OAI --> OpenAI
-  OpenAI --> OAI
-  OAI --> API
+  BS --> AIB
+  AIB --> Hook
+  Hook <--> Cache
+  Cache <--> LS
+  Hook --> Modal
+  Hook --> Rsz
+  Rsz -- POST --> API
+  API --> Sch
+  Sch --> RL
+  RL <--> Admin
+  Admin <--> FS
+  RL --> OAI
+  OAI <--> OpenAI
   API --> AIB
-  AIB --> Cache
-  AIB --> UI
-  API -.읽기.-> Secrets
+  GH -.env 주입.-> API
 ```
 
-### 3.2 배포 아키텍처
+### 1.2 배포 아키텍처
 
 - **정적 리소스**: Firebase Hosting (기존)
-- **SSR / API Routes**: Firebase Cloud Functions (기존 `webframeworks` 실험 기능)
-- **API 키 보관**: Firebase Functions Secret Manager (`OPENAI_API_KEY`)
-- **레이트 리밋 스토리지**: 기존 Firebase Realtime Database (`omctDb` 확장)
-
-새로운 인프라 구성 요소는 없음. 기존 인프라 위에 API 라우트만 추가.
-
----
-
-## 4. 상세 플로우
-
-### 4.1 시퀀스 다이어그램 (Happy Path, 하이브리드 라우팅)
-
-```mermaid
-sequenceDiagram
-  actor U as 유저
-  participant C as Client (BasicStage)
-  participant Cache as Recoil Cache
-  participant API as /api/ai-recommend
-  participant RL as Rate Limiter (RTDB)
-  participant Mini as GPT-4o-mini
-  participant Full as GPT-4o
-
-  U->>C: [AI 추천 받기] 클릭
-  C->>Cache: 이 문항에 캐시된 결과?
-  alt 캐시 있음
-    Cache-->>C: recommendation
-    C-->>U: 하이라이트 + 이유 표시
-  else 캐시 없음
-    C->>C: 이미지 리사이즈 (max 800px)
-    C->>API: POST { imageBase64, stageNum, options }
-    API->>RL: 사용 횟수 확인/증가
-    alt 한도 초과
-      RL-->>API: 429
-      API-->>C: { error: 'RATE_LIMITED' }
-      C-->>U: "오늘 추천 횟수를 모두 사용했어요"
-    else 통과
-      RL-->>API: OK
-      Note over API,Mini: 1차 시도 (저비용 경로)
-      API->>Mini: chat.completions.create(vision, JSON mode)
-      Mini-->>API: { recommendedType, reasoning, confidence }
-      alt confidence ≥ 0.7
-        API-->>C: 200 recommendation (source: 'mini')
-      else confidence < 0.7 (경계 케이스)
-        Note over API,Full: 2차 시도 (고정확도 경로)
-        API->>Full: chat.completions.create(vision, JSON mode)
-        Full-->>API: { recommendedType, reasoning, confidence }
-        API-->>C: 200 recommendation (source: 'full')
-      end
-      C->>Cache: 저장
-      C-->>U: 하이라이트 + 이유 표시
-    end
-  end
-```
-
-**하이브리드 라우팅 정책**
-- **1차: GPT‑4o‑mini** — 저비용/저지연 경로. 대부분의 명확한 케이스는 여기서 종결
-- **2차: GPT‑4o** — mini의 `confidence < 0.7` 일 때만 승격. 경계 케이스 정확도 확보
-- **임계값(0.7) 조정**: 실제 사용 데이터로 A/B 튜닝
-- **폴백 실패 시**: mini 응답 그대로 반환 (유저 경험 최소한 유지)
-
-### 4.2 데이터 흐름 (Data Flow)
-
-```mermaid
-flowchart LR
-  subgraph Input
-    IMG[유저 크롭 이미지<br/>base64 dataURL]
-    OPT[현재 문항의 4개 옵션<br/>type + hex + name]
-  end
-
-  subgraph ClientProcess["Client 전처리"]
-    RS[Canvas로 800×800<br/>리사이즈]
-    B64[base64 재인코딩]
-  end
-
-  subgraph Request
-    REQ["POST body:<br/>{ imageBase64, stageNum, options }"]
-  end
-
-  subgraph ServerProcess["Server 처리"]
-    VAL[스키마 검증]
-    RATE[레이트 리밋 체크]
-    PROMPT[프롬프트 조립]
-    CALL[OpenAI API 호출]
-    PARSE[JSON 파싱 & 검증]
-  end
-
-  subgraph Response
-    RES["{ recommendedType,<br/>reasoning, confidence }"]
-  end
-
-  subgraph ClientRender["Client 렌더링"]
-    HILITE[해당 옵션 하이라이트]
-    TIP[이유 툴팁 표시]
-    SAVE[Recoil 캐시 저장]
-  end
-
-  IMG --> RS
-  RS --> B64
-  OPT --> REQ
-  B64 --> REQ
-  REQ --> VAL
-  VAL --> RATE
-  RATE --> PROMPT
-  PROMPT --> CALL
-  CALL --> PARSE
-  PARSE --> RES
-  RES --> HILITE
-  RES --> TIP
-  RES --> SAVE
-```
-
-### 4.3 상태 다이어그램 (Client UI)
-
-암묵 동의 정책 채택으로 인해 별도 Consent 상태 없음. 개인정보처리방침에만 명시.
-
-```mermaid
-stateDiagram-v2
-  [*] --> Idle
-  Idle --> Loading: [AI 추천 받기] 클릭
-
-  Loading --> Success: API 성공
-  Loading --> Error: API 실패
-  Loading --> RateLimited: 429
-
-  Success --> Idle: 다음 문항 이동
-  Error --> Idle: 재시도 or 닫기
-  RateLimited --> Disabled
-  Disabled --> [*]
-
-  note right of Success
-    - 하이라이트 링
-    - 이유 툴팁
-    - Recoil 캐시 저장
-  end note
-```
+- **SSR / API Routes**: Firebase Cloud Functions v2 (`webframeworks` 실험, Node 20 런타임)
+- **API 키 보관**: GitHub Actions Secrets → 배포 시 `.env` 주입
+- **레이트 리밋 스토리지**: Firestore `aiRecommendRateLimit` 컬렉션 (`firebase-admin` 서버 SDK)
+- **Feature flag**: GitHub Actions Variables → `NEXT_PUBLIC_ENABLE_AI_RECOMMEND`
 
 ---
 
-## 5. 기술 스택
+## 2. API 계약
 
-| 영역 | 기술 | 비고 |
-| --- | --- | --- |
-| **AI 모델 (1차)** | OpenAI **GPT‑4o‑mini** (`gpt-4o-mini-2024-07-18`) | 비용/속도 유리, 대부분 케이스 처리 |
-| **AI 모델 (폴백)** | OpenAI **GPT‑4o** (`gpt-4o-2024-08-06`) | mini의 confidence < 0.7 시 승격 |
-| **SDK** | `openai` npm 패키지 (v4+) | 공식 |
-| **런타임** | Next.js API Route (Node.js) | Firebase Functions로 배포됨 (`webframeworks`) |
-| **비밀 관리** | Firebase Functions Secret Manager | `OPENAI_API_KEY` |
-| **레이트 리밋 스토리지** | Firebase Realtime Database (기존 `omctDb`) | 세션/IP 카운터 |
-| **클라이언트 상태** | Recoil (기존) | `aiRecommendCacheAtom`, `aiRecommendUsageAtom` |
-| **이미지 리사이즈** | 브라우저 Canvas API | 서버 트래픽 최소화 |
-| **국제화** | `next-i18next` (기존) | ko/en 문구 |
-
-### 5.1 신규 의존성
-```json
-{
-  "dependencies": {
-    "openai": "^4.60.0"
-  }
-}
-```
-
-### 5.2 대안 검토
-
-| 옵션 | 장점 | 단점 |
-| --- | --- | --- |
-| GPT‑4o‑mini + GPT‑4o 하이브리드 **(선택)** | 평균 비용/지연 최소화 + 경계 케이스 정확도 확보 | 구현 복잡도 소폭 상승, 임계값 튜닝 필요 |
-| GPT‑4o 단독 | 최고 정확도, 구현 단순 | 항상 최대 비용 발생 |
-| GPT‑4o‑mini 단독 | 최저 비용/최고 속도 | 경계 케이스 정확도 리스크 |
-| GPT‑4.1 | 최고 정확도 | 비용 높음, 속도 느림 |
-| 온디바이스 (TFJS 등) | 프라이버시 강점, 무료 | 정확도↓, 번들 커짐 |
-
-**결론**: **하이브리드 라우팅** 채택.
-- 1차 mini로 저비용 처리 → confidence ≥ 0.7 이면 그대로 반환
-- confidence < 0.7 시 GPT‑4o로 승격 → 정확도 확보
-- 실사용 데이터로 임계값 A/B 튜닝
-- 폴백률(2차 호출 비율) 모니터링 → 20% 이상이면 프롬프트/모델 재검토
-
----
-
-## 6. API 설계
-
-### 6.1 엔드포인트
+### 엔드포인트
 ```
 POST /api/ai-recommend
 ```
 
-### 6.2 Request
+### Request
 
 ```ts
 type AiRecommendRequest = {
-  imageBase64: string;         // "data:image/jpeg;base64,..." 또는 순수 base64
-  stageNum: number;            // 0-8, 현재 문항 번호 (캐시/디버깅용)
+  imageBase64: string;   // data:image/jpeg;base64,... (5MB body limit)
+  stageNum: number;      // 0-9 (9는 BonusStage)
+  sessionId: string;     // 클라이언트 발급 UUID
   options: Array<{
-    type: ColorType;           // 'springwarm' | 'summercool' | ...
-    color: string;             // '#ff6448' 같은 hex
-    name: string;              // 사람이 읽을 수 있는 색 이름 (선택, 디버깅용)
+    type: ColorType;      // 'springwarm' | 'summercool' | ...
+    color: string;        // '#ff6448'
+    name?: string;
+    season: 'spring' | 'summer' | 'autumn' | 'winter';
+    tone: 'warm' | 'cool' | 'bright' | 'mute' | 'light' | 'deep';
   }>;
-  sessionId: string;           // 클라이언트 발급 UUID, 레이트 리밋용
 };
 ```
 
-### 6.3 Response
+### Response
 
 **200 성공**
 ```ts
 type AiRecommendResponse = {
   recommendedType: ColorType;
-  reasoning: string;           // 1-2 문장의 한국어(또는 요청 locale)
-  confidence: number;          // 0.0 - 1.0 (최종 반환 모델의 confidence)
-  usageRemaining: number;      // 이 세션에서 남은 요청 수
-  source: 'mini' | 'full';     // 어떤 모델이 최종 응답했는지 (관찰용)
+  reasoning: string;         // 1-2 문장 (상대 비교 프레이밍)
+  confidence: number;        // 0.0 - 1.0
+  usageRemaining: number;
+  source: 'mini' | 'full';
 };
 ```
 
-**4xx / 5xx 에러**
+**에러**
 ```ts
 type AiRecommendError = {
-  error:
-    | 'INVALID_INPUT'         // 400
-    | 'RATE_LIMITED'          // 429
-    | 'AI_UNAVAILABLE'        // 502 (OpenAI 장애)
-    | 'INTERNAL_ERROR';       // 500
+  error: 'INVALID_INPUT'        // 400
+       | 'NO_FACE_DETECTED'     // 422 (refund 수행)
+       | 'RATE_LIMITED'         // 429 (Retry-After 헤더)
+       | 'AI_UNAVAILABLE'       // 502 (refund 수행)
+       | 'INTERNAL_ERROR';      // 500 (refund 수행)
   message: string;
-  retryAfterSeconds?: number;  // 429일 때
+  retryAfterSeconds?: number;
 };
 ```
 
-### 6.4 프롬프트 (초안)
+### 프롬프트 엔지니어링 전략
 
-**System Message**
+Vision 모델이 최종 진단으로 오해되지 않으면서 4개 중 하나를 신중히 골라내도록, SYSTEM_PROMPT 에 아래 규칙들을 명시적으로 삽입.
+
+**1. 상대 비교 프레이밍 (오해 방지)**
+
+태스크를 "당신의 톤을 판정하라" 가 아닌 "이 4가지 중 가장 어울리는 것을 골라라" 로 재정의.
+
+- 프롬프트에 "You are NOT diagnosing their final personal color type — the 4 options are a limited subset" 명시
+- reasoning 문장에 "제시된 4가지 중에서는" / "네 색 가운데" 등 상대 표현 **필수 포함** 강제
+- "당신은 X톤" / "당신의 퍼스널 컬러는" 같은 진단 문구를 **금지어**로 등록
+
 ```
-You are a professional Korean personal color consultant.
-
-Given a user's face photo and 4 color candidates, choose which single color
-best suits the person based on their skin undertone, eye color, and hair color.
-
-You MUST respond with a JSON object matching this schema exactly:
-{
-  "recommendedType": string,   // one of the provided option types, verbatim
-  "reasoning": string,          // 1-2 sentences in Korean
-  "confidence": number          // 0.0 - 1.0
-}
-
-Do NOT include any text outside the JSON object.
+GOOD: "제시된 4가지 중에서는 이 색이 피부톤을 가장 맑아 보이게 하고 얼굴 윤곽도 살려줘요."
+BAD:  "당신은 겨울 쿨톤이며 이 색이 가장 잘 어울립니다."
 ```
 
-**User Message**
-```
-[image_url or base64 image]
+**2. 옵션에 구조화된 메타데이터 첨부**
 
-옵션:
-[
-  { "type": "springwarm", "color": "#ff6448", "name": "봄 웜" },
-  { "type": "summercool", "color": "#1cace1", "name": "여름 쿨" },
-  ...
-]
+라벨 문자열(`springwarm` 등) 만 넘기지 않고, 각 옵션에 `season`, `tone` 필드를 함께 전송 → AI 가 언더톤을 라벨에서 추론하는 부담 없이 구조화된 신호로 판단.
 
-가장 어울리는 하나를 골라주세요.
+```json
+{ "type": "summerlight", "color": "#f7cdd0", "season": "summer", "tone": "light" }
 ```
 
-### 6.5 OpenAI SDK 호출 예시 (하이브리드 라우팅)
+프롬프트가 시즌-언더톤 매핑을 명시: "spring/autumn imply WARM undertone; summer/winter imply COOL undertone".
 
-```ts
-const CONFIDENCE_THRESHOLD = 0.7;
+**3. 언더톤 판정 방법론 (판단 근거 표준화)**
 
-async function callModel(model: string, dataUri: string, options: Option[]) {
-  const completion = await openai.chat.completions.create({
-    model,
-    response_format: { type: 'json_object' },
-    messages: [
-      { role: 'system', content: SYSTEM_PROMPT },
-      {
-        role: 'user',
-        content: [
-          { type: 'image_url', image_url: { url: dataUri, detail: 'low' } },
-          { type: 'text', text: buildOptionsText(options) },
-        ],
-      },
-    ],
-    max_tokens: 200,
-    temperature: 0.3,
-  });
-  return parseAndValidate(completion.choices[0].message.content);
-}
+"보이는 대로 골라라" 대신 **구체적 관찰 지점**을 지정:
 
-async function getRecommendation(dataUri: string, options: Option[]) {
-  // 1차: mini
-  const miniResult = await callModel('gpt-4o-mini-2024-07-18', dataUri, options);
+- **그림자 영역**: 목·귀 뒷면·턱 아래·관자놀이. 노란/골든/피치 → 웜, 핑크/장미/블루 → 쿨
+- **인접 톤 조화**: 웜은 아이보리/베이지와, 쿨은 그레이/핑크와 자연스러운지
+- **손목 혈관 색**: 녹색 → 웜, 청보라 → 쿨 (보이면)
 
-  if (miniResult.confidence >= CONFIDENCE_THRESHOLD) {
-    return { ...miniResult, source: 'mini' as const };
-  }
+**4. Warm bias 보정 + 한국인 cool prior**
 
-  // 2차: full (경계 케이스만 승격)
-  try {
-    const fullResult = await callModel('gpt-4o-2024-08-06', dataUri, options);
-    return { ...fullResult, source: 'full' as const };
-  } catch (err) {
-    // 폴백 실패 시 mini 응답 그대로 반환 (유저 경험 최소한 유지)
-    console.error('Full model fallback failed', err);
-    return { ...miniResult, source: 'mini' as const };
-  }
-}
-```
+두 층위의 편향이 겹쳐서 실제보다 warm 하게 판정되는 경향이 있음:
+- **사진 자체가 warm 왜곡**: 카메라 자동 화이트밸런스·실내조명·beauty 필터·JPEG 압축이 대체로 노란 캐스트를 얹음
+- **Vision 모델의 warm prior**: 학습 데이터가 위 왜곡을 겪은 이미지들이라 "얼굴 = 살짝 warm" 이라는 내재 편향
 
-**공통 옵션**
-- `detail: 'low'` → 토큰 절감 (얼굴 형태만 인식하면 충분)
-- `temperature: 0.3` → 재현성 확보
-- `response_format: { type: 'json_object' }` → JSON 강제
+프롬프트에 이 두 편향을 명시하고 **borderline 케이스는 무조건 쿨로 기울이도록** 강제.
 
-**관찰 지표 (Sentry/Firebase Analytics로 기록)**
-- 총 요청 중 폴백 발생률
-- mini/full 각각의 평균 지연
-- confidence 히스토그램 (임계값 튜닝용)
+- "Photo lighting / camera white-balance / JPEG compression frequently shift skin toward yellow/warm"
+- "In the Korean population, COOL undertones are demographically MORE common"
+- "When ambiguous or borderline between warm and cool, ALWAYS default to the cool option"
+- "Only pick a warm-season option when the warm undertone is clearly and unmistakably visible"
+
+이 튜닝 이후 여름 라이트 유저가 봄 라이트로 오분류되던 케이스가 개선됨.
+
+**5. Tone 축 (light/mute/bright/deep) 시각 특성 명시**
+
+각 tone 라벨을 얼굴상 어떤 인상으로 판단해야 하는지 세부화. 특히 Light vs Mute 는 실사용에서 잦은 오분류라 별도 규칙:
+
+- **LIGHT**: 피부가 luminous, translucent, dewy. 파스텔의 clarity.
+- **MUTE**: 피부가 matte, soft-powdered, low-contrast. 흐릿한 haze.
+- **BRIGHT**: 눈/헤어에 crisp definition, 얼굴이 vivid 색을 소화 가능.
+- **DEEP**: 눈/헤어와 피부의 strong contrast, 짙은 색이 anchor 역할.
+
+**6. Tone 축 bias 보정**
+
+사진 아티팩트(저조도, 압축) 가 실제보다 mute 하게 보이게 만드는 경향 반영:
+
+- "Borderline light vs mute → prefer LIGHT (photo artifacts more often ADD muteness than remove it)"
+
+**7. 재현성 확보 파라미터**
+
+- `temperature: 0` — 샘플링 랜덤성 제거
+- `seed: 42` — best-effort 재현
+- 같은 이미지·옵션에 대해 같은 응답을 최대한 보장 (튜닝 관찰 용이)
+
+**8. JSON 응답 강제 + 스키마 검증**
+
+- `response_format: { type: 'json_object' }` 로 JSON 강제
+- 서버가 Zod (`aiOpenaiResponseSchema`) 로 파싱·검증
+- `recommendedType` 이 실제 옵션 4개 중 하나인지 크로스체크 (환각 방지)
+- 파싱 실패 → `INVALID_AI_RESPONSE`, 얼굴 없음 → `NONE` 반환 → `NO_FACE_DETECTED` 매핑 + refund
+
+**전체 원문**: `src/utils/aiRecommend/prompt.ts` (`SYSTEM_PROMPT` 상수)
 
 ---
 
-## 7. UI/UX 설계
+### 하이브리드 라우팅
 
-### 7.1 배치
+1. **gpt-4o-mini** 우선 호출 (저비용, 대부분 케이스 처리)
+2. `confidence < CONFIDENCE_THRESHOLD (=0.7)` 이면 gpt-4o 승격
+3. gpt-4o 실패 시 mini 응답 그대로 반환 (`source: 'mini'` 유지)
+4. `recommendedType === 'NONE'` 은 즉시 `NO_FACE_DETECTED` 매핑 (폴백 안 함) + refund
 
-BasicStage의 4 컬러 그리드 하단, 진행 인디케이터 위에 배치.
+라우팅 로직: `src/utils/aiRecommend/openaiClient.ts` (`getRecommendation`)
 
-```
-┌─────────────────────┐
-│    문항 텍스트      │
-├──────┬──────┬───────┤
-│  🎨   │  🎨   │  🎨   │  ← 4개 컬러 옵션
-├──────┼──────┼───────┤
-│  🎨   │       │       │
-├──────┴──────┴───────┤
-│  ✨ AI 추천 받기     │  ← 새 요소 (텍스트 링크 스타일)
-├─────────────────────┤
-│ ● ● ● ○ ○ ○ ○ ○ ○  │  ← 진행 인디케이터
-└─────────────────────┘
-```
-
-### 7.2 상태별 UI
-
-| 상태 | 표시 |
-| --- | --- |
-| **Idle** | `✨ AI 추천 받기` (회색 텍스트 링크) |
-| **Loading** | 스피너 + "AI가 분석 중..." (2‑7초) |
-| **Success** | 추천 옵션에 반짝이는 링 애니메이션 + 하단 툴팁 "AI 추천: [이유]" |
-| **Error** | 스낵바 "지금은 추천을 받을 수 없어요" + 재시도 링크 |
-| **RateLimited** | 버튼 비활성화 + "오늘 사용 가능 횟수를 모두 사용했어요" |
-
-> 별도 동의 모달 없음. 개인정보처리방침에 명시된 내용에 대한 암묵 동의로 처리.
-
-### 7.3 하이라이트 애니메이션
-
-- 선택된 옵션 컬러 원 주위에 CSS `box-shadow` + `keyframes` 로 부드러운 pulse
-- 접근성: `prefers-reduced-motion` 존중해 애니메이션 off
-
-### 7.4 다국어
-
-- 신규 번역 키 (ko/en 동시 첫 릴리즈):
-  - `aiRecommend.button`
-  - `aiRecommend.loading`
-  - `aiRecommend.error.generic`
-  - `aiRecommend.error.rateLimited`
-  - `aiRecommend.result.prefix`
-
-> 동의 모달 미채택. Consent 관련 키 없음.
+공통 호출 파라미터: `response_format: json_object`, `max_tokens: 200`, `temperature: 0`, `seed: 42`, `image_url.detail: 'low'`.
 
 ---
 
-## 8. 프라이버시 & 준수사항
+## 3. UI/UX
 
-### 8.1 데이터 처리 원칙
-- **최소 수집**: 얼굴 사진만 전송, 이름/이메일 등 PII 미포함
-- **즉시 폐기**: 서버 응답 후 이미지 메모리에서 즉시 폐기, 파일/로그 저장 금지
-- **로그 정책**: 이미지·base64 절대 로깅 금지. 메타데이터(요청 timestamp, session hash, latency, tokens)만 기록
-- **저장 없음**: RTDB에는 카운터만 저장, 이미지·응답 텍스트 미저장
+### 상태별 표시
 
-### 8.2 OpenAI 데이터 정책
-- OpenAI API는 기본적으로 학습에 사용되지 않음 (2023년 3월 이후)
-- 30일 abuse monitoring 로그는 존재. Enterprise 계약 시 Zero Data Retention 옵션 가능
-- 개인정보처리방침에 "얼굴 사진이 OpenAI로 전송되어 분석에 사용됩니다"를 명시할 것
+| 상태 | 트리거 | 표시 |
+| --- | --- | --- |
+| `idle` | 초기 | "✨ AI 추천 받기" (텍스트 링크) |
+| `loading` | 요청 중 | 스피너 + "AI가 분석 중..." (평균 2‑7초) |
+| `success` | 200 또는 캐시 히트 | 옵션 pulse 하이라이트 + "이 4가지 중 AI 픽: [이유]" 배너 |
+| `error` | 실패 | "지금은 추천을 받을 수 없어요" or "얼굴이 잘 보이지 않아요" + 재시도 링크 |
+| `rateLimited` | 429 | 비활성 + "오늘 사용 가능 횟수 모두 사용" |
+| `disabled` | feature flag OFF | 렌더 안 함 |
 
-### 8.3 동의 절차 (암묵 동의)
-- 별도 모달 없음 — UX 매끄러움 우선
-- **개인정보처리방침에 명시**:
-  - "AI 색상 추천 기능 사용 시 사용자가 업로드한 얼굴 이미지가 OpenAI(gpt‑4o‑mini / gpt‑4o) API로 전송됩니다"
-  - "이미지는 서버 측에서 응답 후 즉시 폐기되며, 저장되지 않습니다"
-  - "OpenAI는 API 데이터를 학습에 사용하지 않으며, abuse monitoring 목적의 30일 로그가 존재할 수 있습니다"
-- AI 추천 버튼 근처에 개인정보처리방침 링크 노출 (`i` 아이콘 등 subtle 표시) — 유저가 원할 때 언제든 확인 가능
-- 향후 GDPR/EU 트래픽 대응 시 명시적 동의 모달 재도입 검토
+### 하이라이트 & 접근성
 
-**리스크 인식**
-- 암묵 동의는 UX 편의성 우선. 대한민국 개인정보보호법 관점에서는 처리방침 명시로 충분하나, EU/UK 유저 대응에서는 GDPR 명시적 동의 요구될 수 있음
-- 글로벌 확장 시 CMP 도입 검토 필요 (AdSense 승인 프로세스에서도 이미 CMP 세팅 완료됨 — 재활용 가능)
+- CSS `box-shadow` + `keyframes` 로 부드러운 pulse
+- `prefers-reduced-motion` 존중해 애니메이션 대신 정적 outline 폴백
+
+### i18n
+
+`aiRecommend.*` 키가 `public/locales/{ko,en}/common.json` 에 존재.
 
 ---
 
-## 9. 비용 & 성능 견적
+## 4. 프라이버시 & 동의
 
-### 9.1 토큰당 비용 (GPT‑4o 기준, 2026-07 기준)
-- Input: $2.50 / 1M tokens
-- Output: $10.00 / 1M tokens
-- Vision (`low` detail): 이미지당 ~85 tokens
+### 4.1 데이터 처리 원칙
 
-### 9.1.b GPT‑4o‑mini 가격
-- Input: **$0.15** / 1M tokens
-- Output: **$0.60** / 1M tokens
-- 이미지 토큰 계산은 4o와 동일
+- **최소 수집**: 얼굴 사진만 전송, PII 미포함
+- **즉시 폐기**: 서버 응답 후 이미지 메모리에서 폐기. 파일/로그 저장 금지
+- **IP 저장**: SHA-256 해시 앞 32자리만 (레이트 리밋 목적, 원본 미저장)
+- **OpenAI 정책**: API 데이터 학습 미사용, 30일 abuse-monitoring 로그 존재 가능
 
-### 9.2 요청당 추정
-| 항목 | 토큰 |
-| --- | --- |
-| System prompt | ~120 |
-| Image (low detail) | ~85 |
-| Options JSON | ~150 |
-| Output | ~100 |
-| **합계** | ~455 tokens |
+### 4.2 명시적 동의 모달
 
-**단일 호출당 비용**
+원 설계는 암묵 동의였으나 앱 내 개인정보처리방침 페이지 부재로 **명시적 동의 모달**로 전환.
+
+- **컴포넌트**: `AiConsentModal.tsx` (shareModal 과 동일한 스낵바 스타일)
+- **트리거**: AI 추천 버튼 최초 클릭 시. `consent === 'granted'` 아니면 요청 지연
+- **저장**: `aiRecommendConsentState` Recoil atom + `localStorageEffect`. 재방문 시 재동의 불필요
+- **거부 시**: 카운트 소모 없음, 재클릭 시 모달 재표시 (재고 가능)
+- **모달 문구**: 이용 목적 / 전송 항목 / 전송 대상 (OpenAI gpt-4o-mini/4o) / 보유 및 이용 기간 (즉시 폐기) + OpenAI 정책 안내 + 거부 가이드
+
+**후속 과제**: 정식 `/privacy` 페이지 신설 시 이 모달을 링크로 대체 검토.
+
+---
+
+## 5. 비용 & 레이트 리밋
+
+### 5.1 단일 호출 비용
+
+- Vision `detail: 'low'`: 이미지당 ~85 tokens
+- 요청당 합계 ~455 tokens (system + image + options + output)
 - mini 단독: **~$0.0001** (약 0.15원)
 - full 단독: **~$0.0015** (약 2원)
+- 하이브리드 평균 (폴백률 20% 가정): **~$0.0004** (약 0.6원)
 
-**하이브리드 평균 (폴백률 20% 가정)**
-- 평균 비용: `0.8 × $0.0001 + 0.2 × ($0.0001 + $0.0015)` = **~$0.0004** (약 0.6원)
-- 4o 단독 대비 **약 73% 절감**, mini 단독 대비 4배 증가 (그러나 정확도 확보)
+### 5.2 레이트 리밋
 
-### 9.3 월간 예산 시나리오 (하이브리드 + 관대 레이트 리밋 기준)
+Firestore 카운터, `refund` 로 실패 시 환원. localhost bypass.
 
-**설정된 알람 임계값**: **$30/월** (기대 시나리오 대비 약 2.3배 여유)
+**3층 상한** (각각 목적이 다름):
 
-**레이트 리밋**: 세션당 9회 / IP 일일 30회 → 상한 시나리오의 세션당 요청 가정 상향
+| 층위 | 상한 | 리셋 | 목적 |
+| --- | --- | --- | --- |
+| 세션 | 10 | 페이지 새로고침 | 진단 흐름을 완주할 수 있는 최대치 (= BasicStage 9 + BonusStage 1) |
+| IP | 30/일 | UTC 자정 | 비용·어뷰징 보호의 실질 라인 (약 3세션 완주 분) |
+| 월 | \$30 | OpenAI 대시보드 알람 | 최후 안전장치 → flag OFF |
 
-| 시나리오 | DAU | AI 사용률 | 세션당 요청 (평균) | 월 요청 | 월 비용 (하이브리드) | 알람 상태 | 참고: 4o 단독 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| 보수적 | 500 | 15% | 1.5 | ~3,400 | **~$1.5** | 🟢 안전 (5%) | ~$5 |
-| 기대 | 2,000 | 25% | 2.5 | ~37,500 | **~$16** | 🟢 안전 (53%) | ~$56 |
-| 상한 (관대 리밋 소진) | 5,000 | 40% | 6.0 | ~360,000 | **~$160** | 🔴 초과 (533%) | ~$540 |
+- **세션 = 10** 은 "유저가 이론적으로 AI 도움을 받을 수 있는 최대 지점 수" 와 같음. `sessionId` 는 Recoil in-memory 만 사용해 새로고침 시 리셋되므로, 실질 어뷰징 방어는 IP 계층이 담당.
+- 실패한 요청은 refund 되어 성공 카운트만 소진. 재시도 이중 차감 없음.
+- localhost (127.0.0.1 / ::1 / localhost / unknown) 은 카운트 안 함.
+- IP 초과 시 429 + `Retry-After` 헤더에 UTC 자정까지 초 반환.
 
-- 폴백률 20%는 초기 가정. 실 데이터로 재보정 필요.
-- 관대 레이트 리밋(세션당 9회) 채택으로 인해 **상한 시나리오의 위험이 이전보다 커짐** (평균 요청 3 → 6으로 상향).
-- **대응 방안**:
-  1. 알람 트리거 시 즉시 `NEXT_PUBLIC_ENABLE_AI_RECOMMEND=false` 로 재배포 → 기능 OFF
-  2. 또는 문서 Section 5의 `CONFIDENCE_THRESHOLD` 하향 조정으로 폴백률 감소 (예: 0.7 → 0.5)
-  3. 또는 레이트 리밋 축소 (세션당 9 → 3)
+### 5.3 월 예산
 
-### 9.4 응답 시간
+- **OpenAI 대시보드 hard limit: $30/월**
+- 초과 시 즉시 `NEXT_PUBLIC_ENABLE_AI_RECOMMEND='false'` 재배포로 기능 OFF
+- 필요 시 `CONFIDENCE_THRESHOLD` 하향(0.7→0.5)으로 폴백률 감소, 또는 세션 상한 축소
 
-| 시나리오 | 서버 지연 (p50 → p95) | 총 사용자 체감 |
-| --- | --- | --- |
-| mini만으로 종결 (80%) | 1.5 → 3초 | **2‑3.5초** |
-| mini → 4o 폴백 (20%) | 3.5 → 7초 | **4‑7.5초** |
-| 평균 (0.8×mini + 0.2×hybrid) | ~2초 | **~2.5‑4.5초** |
+### 5.4 응답 시간
 
-- 클라이언트 리사이즈: <500ms
-- 로딩 UI 필수 (폴백 시 최대 7초 대기 가능성)
+| 시나리오 | p50 → p95 |
+| --- | --- |
+| mini만으로 종결 (~80%) | 1.5 → 3초 |
+| mini → full 폴백 (~20%) | 3.5 → 7초 |
 
----
-
-## 10. 구현 마일스톤
-
-### Phase 0 — 검증 (0.5일)
-- 로컬 스크립트로 OpenAI API에 이미지 3‑5장 수동 요청
-- 프롬프트 정확도 튜닝
-- 응답 JSON 파싱 안정성 확인
-
-### Phase 1 — 백엔드 (1‑2일)
-- [ ] `openai` 패키지 설치
-- [ ] `pages/api/ai-recommend.ts` 라우트 구현
-- [ ] Zod 스키마로 요청/응답 검증
-- [ ] **하이브리드 라우팅 로직** (`getRecommendation`: mini 호출 → confidence 판정 → 필요 시 full 폴백)
-- [ ] `CONFIDENCE_THRESHOLD` 상수 및 관련 튜닝 훅
-- [ ] Rate limiter (`omctDb` 확장, 세션/IP 카운터)
-- [ ] `OPENAI_API_KEY` Secret 등록 (로컬 `.env.local`, Firebase Functions Secret)
-- [ ] 관찰 로깅: `source`, `confidence`, `latency`, `fallbackTriggered` 를 Sentry breadcrumb에 남김
-- [ ] 단위 테스트 (프롬프트 조립, 파싱, 폴백 트리거, 폴백 실패 처리)
-
-### Phase 2 — 프론트엔드 (1‑2일)
-- [ ] Recoil atoms: `aiRecommendCacheAtom`, `aiRecommendUsageAtom`
-- [ ] `useAiRecommend` 훅 (요청, 캐시, 에러 처리)
-- [ ] `AiRecommendButton` 컴포넌트 (상태별 UI)
-- [ ] BasicStage 통합 (9문항 모두)
-- [ ] 하이라이트 애니메이션 (styled‑components)
-- [ ] ko + en 번역 키 동시 추가
-- [ ] 개인정보처리방침 링크 노출 (버튼 근처)
-
-### Phase 3 — 통합 & 릴리즈 (1일)
-- [ ] Feature flag: **환경변수** `NEXT_PUBLIC_ENABLE_AI_RECOMMEND=true/false` (초기 off로 배포 → 준비 완료 시 on)
-- [ ] Sentry 이벤트 추적 (요청 수, 에러율, 지연)
-- [ ] 스테이징 배포 및 QA (사진 다양성 테스트, ko/en 스위치 확인)
-- [ ] **개인정보처리방침 문구 업데이트 (담당: 수야)** — Section 8.3 문구 기반
-- [ ] OpenAI 대시보드에 $30/월 예산 알람 세팅
-- [ ] 프로덕션 롤아웃 (환경변수 on 배포)
-
-### Phase 4 — 관찰 & 조정 (지속)
-- 실 사용량 vs 예산 모니터링
-- **폴백률 대시보드**: 폴백률이 30% 초과 시 프롬프트 재검토 또는 mini 모델 변경 검토
-- **confidence 히스토그램**: 실제 분포 확인 후 임계값 0.7 재조정 (예: 0.6 또는 0.75)
-- 정확도 피드백 수집 (선택적 유저 설문)
-- mini vs full 결과 정성 비교 (샘플링)
-
-**총 소요**: 3‑5일 (1인 기준, Phase 0‑3)
+로딩 UI 필수. 폴백 시 최대 7초 대기.
 
 ---
 
-## 11. 리스크 및 대응
+## 6. 리스크 & 확장
 
-| 리스크 | 심각도 | 대응 |
-| --- | --- | --- |
-| OpenAI API 장애 | 중 | Graceful fallback: 스낵바로 안내, 진단은 계속 진행 |
-| 응답이 non‑JSON | 중 | JSON mode + 파싱 실패 시 재시도 1회, 실패 시 에러 |
-| 비용 폭발 | 상 | 레이트 리밋 + 세션 캐시 + 월 예산 알람 (OpenAI 대시보드) |
-| 어뷰징 (봇 트래픽) | 상 | IP당 일일 제한 + Cloudflare Turnstile 등 CAPTCHA (필요시 추후) |
-| 얼굴이 없는 이미지 업로드 | 중 | OpenAI 프롬프트에 "얼굴이 없으면 recommendedType='NONE' 반환" 지시 후 클라이언트에서 에러 처리 |
-| 유저가 AI만 믿고 무성의 클릭 | 저 | 추천 문구를 subtle하게, "당신의 판단을 참고용으로 도와드립니다" |
-| 프라이버시 이슈 | 상 | 명시적 동의, 로깅 금지, 개인정보처리방침 업데이트 |
-| 다양한 인종/피부톤에서 편향 | 중 | Phase 0에서 다양한 샘플로 검증, 편향 발견 시 프롬프트 튜닝 |
+### 6.1 리스크 대응
 
----
+| 리스크 | 대응 |
+| --- | --- |
+| OpenAI 장애 | 하이브리드 폴백 + 실패 시 refund + UI 재시도 |
+| non-JSON / 스키마 불일치 | `json_object` 강제 + Zod 검증 + 옵션 포함 여부 크로스체크 |
+| 비용 폭발 | 세션/IP 카운터 + 캐시 + $30/월 hard limit + flag OFF 즉시 롤백 |
+| 어뷰징 | IP 제한 + SHA-256 해시 저장. 필요 시 Turnstile 후속 |
+| 얼굴 없음 | 프롬프트에 `NONE` 지시 → 422 매핑 + refund |
+| AI 맹신 | 프롬프트 상대 비교 프레이밍 + UI 라벨 "이 4가지 중" |
+| 편향 (warm bias, light↔mute) | 프롬프트 언더톤 방법론 + 한국인 쿨 prior + tone 축 시각 특성 |
+| 재시도 이중 차감 | 실패 시 refund |
 
-## 12. 확장 여지
+### 6.2 후속 검토
 
-### 향후 고려 가능한 개선
-- **최종 결과 페이지**: "AI가 본 당신" 코멘트 섹션
-- **선택 vs AI 통계**: 유저 선택과 AI 추천 일치율 표시 (동의 기반 익명 집계)
-- **온디바이스 사전 필터**: 얼굴 검출 후에만 API 호출 (비용 절감)
-- **다중 AI 앙상블**: 여러 모델 결과 통합 (정확도 향상)
-- **개인화 프롬프트**: 이전 선택 이력을 프롬프트에 반영
-- **음성 추천**: TTS로 접근성 향상
+- **정식 `/privacy` 페이지**: 스낵바 동의를 페이지 링크로 대체
+- **BonusStage AI 재검토**: 실사용 데이터에서 유용성 낮으면 제거
+- **선택 vs AI 통계**: 동의 기반 익명 집계로 일치율 노출
+- **온디바이스 얼굴 검출**: 얼굴 없는 이미지 서버 호출 사전 차단
+- **최종 결과 페이지 AI 코멘트**: "AI가 본 당신" 요약 문단
 
 ---
 
-## 13. 미결 사항 (Open Questions)
+## 7. 관련 파일
 
-모든 결정 확정 (2026-07-02):
+### 서버측
+- `src/pages/api/ai-recommend.page.ts` — API 라우트 (POST 핸들러)
+- `src/utils/aiRecommend/schema.ts` — Zod 스키마
+- `src/utils/aiRecommend/prompt.ts` — SYSTEM_PROMPT + `buildUserText`
+- `src/utils/aiRecommend/openaiClient.ts` — 하이브리드 라우팅, `CONFIDENCE_THRESHOLD`
+- `src/utils/aiRecommend/rateLimiter.ts` — `checkAndConsume`, `refund`, 상한, localhost bypass
+- `src/utils/aiRecommend/adminDb.ts` — firebase-admin 초기화 (ADC / `FIREBASE_SERVICE_ACCOUNT_JSON`)
+- `src/utils/aiRecommend/typeMeta.ts` — `ColorType → {season, tone}` 매핑
 
-1. ✅ **모델 라우팅**: 하이브리드 (mini 1차 + full 폴백, `confidence < 0.7` 시 승격)
-2. ✅ **하이브리드 임계값**: `CONFIDENCE_THRESHOLD = 0.7` — 실사용 데이터로 재조정
-3. ✅ **레이트 리밋 (관대 프로파일)**:
-   - 세션당 **9회** (모든 문항에서 가능)
-   - IP당 일일 **30회**
-   - ⚠ 상한 시나리오 비용 리스크 → Section 9.3 참조
-4. ✅ **월 예산 알람**: **$30/월** (OpenAI 대시보드). 초과 시 알람 → feature flag OFF
-5. ✅ **첫 릴리즈 범위**:
-   - **하이라이트 + 이유 텍스트** 함께 노출
-   - **9문항 모두**에서 AI 추천 버튼 노출
-6. ✅ **동의 방식**: **암묵 동의** — 별도 동의 모달 없이 **개인정보처리방침에 명시**. UX 매끄러움 우선
-7. ✅ **다국어**: **ko + en 동시** 첫 릴리즈부터
-8. ✅ **Feature flag 방식**: **환경변수** (`NEXT_PUBLIC_ENABLE_AI_RECOMMEND`). 즉시 on/off 필요 시 재배포 감수
-9. ✅ **폴백 실패 정책**: **mini 응답 반환** (유저에게 최소한의 답변 제공, `source: 'mini'`로 관찰 로그 기록)
-10. ✅ **개인정보처리방침 담당**: **본인(수야)** 직접 작성 및 배포
+### 클라이언트측
+- `src/hooks/useAiRecommend.ts` — 요청 훅, consent 게이트, 상태 머신
+- `src/components/AiRecommend/index.tsx` — `AiRecommendButton`
+- `src/components/AiRecommend/AiConsentModal.tsx` + `consentStyle.ts` — 동의 모달
+- `src/components/AiRecommend/style.ts` — 버튼 스타일
+- `src/recoil/aiRecommend.ts` — 4개 atom (cache / sessionId / usageRemaining / consent)
+- `src/utils/imageResize.ts` — Canvas 리사이즈
 
----
+### 통합 지점
+- `src/pages/choice-color/BasicStage/index.tsx` — pulse 하이라이트 + 버튼
+- `src/pages/choice-color/BonusStage/index.tsx` — 버튼 (`stageNum=9`)
 
-## 14. 관련 파일 & 참조
+### 설정·번역·CI
+- `public/locales/{ko,en}/common.json` — `aiRecommend.*` 키
+- `.env.example` — 환경변수 문서화
+- `.github/workflows/firebase-hosting-merge.yml` — Secret 주입
+- `next.config.js` — `pageExtensions: ['page.tsx', 'page.ts']`, `outputFileTracingIncludes`
+- `tsconfig.json` — `@Root/*` 별칭
 
-### 신규 추가 예정 파일
-- `src/pages/api/ai-recommend.ts` — API 라우트
-- `src/hooks/useAiRecommend.ts` — 클라이언트 훅
-- `src/components/AiRecommend/AiRecommendButton.tsx`
-- `src/recoil/aiRecommend.ts` — Recoil atoms
-- `src/utils/openaiClient.ts` — SDK wrapper (하이브리드 라우팅 포함)
-- `src/utils/imageResize.ts` — 클라이언트 리사이즈
-- `public/locales/{ko,en}/common.json` — 번역 키 추가 (ko/en 동시)
-
-> `AiConsentModal` 컴포넌트 미채택 (암묵 동의 정책).
-
-### 수정 예정 파일
-- `src/pages/choice-color/BasicStage/index.tsx` — 버튼 통합
-- `src/utils/omctDb.ts` — 레이트 리밋 카운터 추가
-- `.env.local` / `.env.example` — 환경변수 문서화
-- `.github/workflows/firebase-hosting-merge.yml` — Secret 주입 추가
+### 검증 도구
+- `scripts/ai-recommend-check.ts` — 로컬 CLI (`yarn ai-recommend:check <image>`) — mini/full 응답 수동 비교
 
 ### 참조
-- 기존 도메인 문서: [personal-color-algorithm.md](./personal-color-algorithm.md)
-- OpenAI Vision API 공식: https://platform.openai.com/docs/guides/vision
-- Firebase Functions Secret Manager: https://firebase.google.com/docs/functions/config-env#secret-manager
+- [personal-color-algorithm.md](./personal-color-algorithm.md) — 12타입 도메인 문서
+- OpenAI Vision: https://platform.openai.com/docs/guides/vision
+- Firebase webframeworks: https://firebase.google.com/docs/hosting/frameworks/nextjs
+
+---
+
+## 8. AI 추천 핵심 흐름
+
+### 8.1 요청 → OpenAI → 응답
+
+```mermaid
+sequenceDiagram
+  participant C as Client<br/>(AiRecommendButton)
+  participant API as /api/ai-recommend
+  participant OAI as OpenAI<br/>(gpt-4o-mini → gpt-4o)
+
+  C->>C: 이미지 800×800 리사이즈
+  C->>API: POST { 이미지(base64), 4옵션 }
+  API->>API: 프롬프트 조립<br/>system + image_url + options JSON
+  API->>OAI: chat.completions<br/>(json_object, temp=0, seed=42)
+  OAI-->>API: { recommendedType, reasoning, confidence }
+  API->>API: JSON 파싱 + Zod 스키마 검증
+  API-->>C: 200 { recommendedType, reasoning, ... }
+```
+
+핵심 상세:
+- 프롬프트 문안 & 옵션 직렬화: `src/utils/aiRecommend/prompt.ts`
+- 하이브리드 라우팅 (mini → confidence → full): `src/utils/aiRecommend/openaiClient.ts` (`getRecommendation`)
+- 레이트 리밋 & refund: `src/utils/aiRecommend/rateLimiter.ts`
+- 동의 게이트: §4.2
+
+### 8.2 관찰 지표
+
+프로덕션 켠 이후 데이터 축적 시 확인:
+
+- **폴백률** = full 호출 / 전체 요청. 20% 초과 시 프롬프트 재검토
+- **confidence 히스토그램**: mini 응답의 분포. 임계값 0.7 재조정 근거
+- **refund 발생률**: AI_UNAVAILABLE 지배적이면 OpenAI 계약/키 상태 점검
+- **동의 거부율**: 30% 이상이면 모달 문구 재검토
+- **월 예산**: OpenAI 대시보드 알람 ($30/월). 초과 시 flag OFF

--- a/src/pages/choice-color/BonusStage/index.tsx
+++ b/src/pages/choice-color/BonusStage/index.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import { useTranslation } from 'next-i18next';
+import { useRecoilValue } from 'recoil';
 import getBonusColorOptions from '@Utils/getBonusColorOptions';
 import ROUTE_PATH from '@Constant/routePath';
 import LoadingIndicator from '@Components/LoadingIndicator';
@@ -8,6 +9,7 @@ import Guidance from '../Guidance';
 
 import AiRecommendButton from '@Components/AiRecommend';
 import { getSeasonToneByType } from '@Utils/aiRecommend/typeMeta';
+import { aiRecommendCacheState } from '@Recoil/aiRecommend';
 
 import * as S from './style';
 
@@ -33,6 +35,9 @@ function BonusStage({
     ? getBonusColorOptions(bonusColorTypes)
     : null;
 
+  const aiRecommendCache = useRecoilValue(aiRecommendCacheState);
+  const recommendedType = aiRecommendCache[BONUS_STAGE_NUM]?.recommendedType;
+
   const onBonusClick = (type: ColorType) => {
     const params = new URLSearchParams(searchParams);
     params.set('colorType', type);
@@ -54,6 +59,7 @@ function BonusStage({
             key={type + index}
             colors={colors}
             isSelected={colors.includes(selectedColor)}
+            isRecommended={type === recommendedType}
             onClick={() => onBonusClick(type)}
           >
             <Image src={userImg} alt="사용자 이미지" width={100} height={100} />


### PR DESCRIPTION
## Summary

두 개의 커밋:

1. **fix(ai-recommend): BonusStage 에서 AI 추천 pulse 하이라이트 누락**
   - BonusStage 통합 시 `isRecommended` prop 미전달로 pulse 애니메이션이 안 뜨던 버그
   - BasicStage 는 정상, BonusStage 만 누락

2. **docs: AI 추천 문서 슬림화 + README 서비스 흐름 다이어그램**
   - `docs/domain/ai-color-recommendation.md` 902 → 424 라인 (~53% 감소)
   - 프롬프트 엔지니어링 전략 8가지 기법을 명시적으로 문서화
   - Warm bias 이중 편향 (사진 왜곡 + 모델 prior) 및 대응 근거 설명
   - 세션당 10회 상한의 근거 (BasicStage 9 + BonusStage 1) 명시
   - 3층 상한 (세션 / IP / 월) 표로 정리
   - README 에 전체 유저 여정 flowchart 추가

## Test plan

- [x] BonusStage 에서 AI 추천 후 pulse 링이 표시되는지 확인
- [x] `yarn lint` 통과
- [x] mermaid 다이어그램 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)