### PR TITLE
docs(ai-recommend): mermaid 다이어그램 렌더 오류 수정

### DIFF
--- a/docs/domain/ai-color-recommendation.md
+++ b/docs/domain/ai-color-recommendation.md
@@ -56,7 +56,7 @@ graph TB
   end
 
   subgraph Server["Server (API on Firebase Cloud Functions)"]
-    API[/pages/api/ai-recommend.page.ts]
+    API["/pages/api/ai-recommend.page.ts"]
     Sch[Zod 스키마 검증]
     RL["rateLimiter.ts<br/>checkAndConsume / refund"]
     OAI["openaiClient.ts<br/>하이브리드 라우팅"]
@@ -86,7 +86,7 @@ graph TB
   RL --> OAI
   OAI <--> OpenAI
   API --> AIB
-  GH -.env 주입.-> API
+  GH -. env 주입 .-> API
 ```
 
 ### 1.2 배포 아키텍처
@@ -406,9 +406,9 @@ Firestore 카운터, `refund` 로 실패 시 환원. localhost bypass.
 
 ```mermaid
 sequenceDiagram
-  participant C as Client<br/>(AiRecommendButton)
-  participant API as /api/ai-recommend
-  participant OAI as OpenAI<br/>(gpt-4o-mini → gpt-4o)
+  participant C as "Client<br/>(AiRecommendButton)"
+  participant API as "/api/ai-recommend"
+  participant OAI as "OpenAI<br/>(gpt-4o-mini → gpt-4o)"
 
   C->>C: 이미지 800×800 리사이즈
   C->>API: POST { 이미지(base64), 4옵션 }


### PR DESCRIPTION
## Summary
- `docs/domain/ai-color-recommendation.md` 의 두 mermaid 다이어그램이 GitHub / IDE 프리뷰에서 "Lexical error" 로 렌더되지 않던 문제 수정
- 문법 자체만 손보고 다이어그램 의미/구조는 그대로 유지

## 변경 내역
1. **컴포넌트 다이어그램** (`graph TB`)
   - `API[/pages/api/ai-recommend.page.ts]` — 평행사변형 shape 를 `[/` 로 열고 `/]` 로 닫지 않아 다음 노드까지 라벨로 삼키던 파싱 실패 → `API["/pages/api/ai-recommend.page.ts"]` 로 인용
   - `GH -.env 주입.-> API` — 점선 화살표 라벨 토큰이 붙어 혼동 → `GH -. env 주입 .-> API` 로 공백 분리
2. **시퀀스 다이어그램** (`sequenceDiagram`)
   - `participant C as Client<br/>(AiRecommendButton)` 형태의 참여자 별칭이 `<br/>` `()` 특수문자 때문에 렌더 실패 → 별칭 전체를 큰따옴표로 감쌈 (`C`, `API`, `OAI` 3개)

## Test plan
- [x] GitHub PR "Files changed" 탭에서 mermaid 두 블록이 정상 렌더링되는지 확인
- [x] VS Code Markdown Preview (또는 다른 로컬 프리뷰) 에서 두 다이어그램 렌더 확인
- [x] 컴포넌트 다이어그램의 노드/에지 구조가 이전 의도와 동일한지 육안 확인
- [x] 시퀀스 다이어그램의 participant 라벨이 줄바꿈 포함해 원래대로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)