### PR TITLE
feat(all-types-view): 남자 연예인 compass chart 추가 + axis 하이라이트

### DIFF
--- a/src/pages/all-types-view/CompassChart/constants.ts
+++ b/src/pages/all-types-view/CompassChart/constants.ts
@@ -58,3 +58,21 @@ export const SEASON_LABELS = [
   { key: 'autumn', label: '가을 AUTUMN', angle: 225, anchorIndex: 7 },
   { key: 'winter', label: '겨울 WINTER', angle: 315, anchorIndex: 10 },
 ] as const;
+
+// Maps each of the 12 color types (by their index in color[]) to the axis
+// label that best characterizes it. The two "Warm" axes (spring vs autumn)
+// and two "Cool" axes (summer vs winter) are disambiguated by suffix.
+export const TYPE_INDEX_TO_AXIS_KEY = [
+  'bright', // 0  springbright
+  'warm-spring', // 1  springwarm
+  'light', // 2  springlight
+  'light', // 3  summerlight
+  'cool-summer', // 4  summercool
+  'mute', // 5  summermute
+  'mute', // 6  autumnmute
+  'warm-autumn', // 7  autumnwarm
+  'deep', // 8  autumndeep
+  'deep', // 9  winterdeep
+  'cool-winter', // 10 wintercool
+  'bright', // 11 winterbright
+] as const;

--- a/src/pages/all-types-view/CompassChart/index.tsx
+++ b/src/pages/all-types-view/CompassChart/index.tsx
@@ -12,6 +12,7 @@ import {
   CHART_SIZE,
   OUTER_RADIUS,
   SEASON_LABELS,
+  TYPE_INDEX_TO_AXIS_KEY,
   getAvatarAngleDeg,
   polarToCartesian,
 } from './constants';
@@ -22,6 +23,7 @@ type Props = {
   hoveredIndex: number | undefined;
   onSelect: (index: number) => void;
   onHover: (index: number | undefined) => void;
+  celebrityIndex?: number;
 };
 
 const SEASON_LABEL_OFFSET = OUTER_RADIUS + 22;
@@ -33,8 +35,20 @@ function quadrantPath(startAngleDeg: number): string {
   return `M ${CENTER} ${CENTER} L ${start.x} ${start.y} A ${OUTER_RADIUS} ${OUTER_RADIUS} 0 0 1 ${end.x} ${end.y} Z`;
 }
 
-function CompassChart({ selectedIndex, hoveredIndex, onSelect, onHover }: Props) {
+function CompassChart({
+  selectedIndex,
+  hoveredIndex,
+  onSelect,
+  onHover,
+  celebrityIndex = 0,
+}: Props) {
   const { t } = useTranslation('common');
+
+  const activeIndex = hoveredIndex ?? selectedIndex;
+  const highlightedAxisKey =
+    activeIndex !== undefined ? TYPE_INDEX_TO_AXIS_KEY[activeIndex] : undefined;
+  const highlightColor =
+    activeIndex !== undefined ? color[activeIndex].textColor : undefined;
 
   return (
     <S.Wrapper>
@@ -122,19 +136,21 @@ function CompassChart({ selectedIndex, hoveredIndex, onSelect, onHover }: Props)
 
         <circle cx={CENTER} cy={CENTER} r="5" fill="#8a6d3b" />
 
-        {/* 6 axis labels inside the center circle */}
+        {/* 8 axis labels inside the center circle */}
         {AXIS_LABELS.map(({ key, label, angle }) => {
           const { x, y } = polarToCartesian(angle, AXIS_LABEL_RADIUS);
+          const isHighlighted = key === highlightedAxisKey;
           return (
             <text
               key={key}
               x={x}
               y={y + 3}
               textAnchor="middle"
-              fontSize="10"
+              fontSize={isHighlighted ? 11 : 10}
               fontFamily="'Noto Sans KR', sans-serif"
-              fontWeight="500"
-              fill="#7a5c2a"
+              fontWeight={isHighlighted ? 700 : 500}
+              fill={isHighlighted && highlightColor ? highlightColor : '#7a5c2a'}
+              style={{ transition: 'font-size 160ms ease, fill 160ms ease' }}
             >
               {label}
             </text>
@@ -163,7 +179,8 @@ function CompassChart({ selectedIndex, hoveredIndex, onSelect, onHover }: Props)
           getAvatarAngleDeg(index),
           AVATAR_RING_RADIUS
         );
-        const representative = resultColorData[type].celebrities[0];
+        const celebs = resultColorData[type].celebrities;
+        const representative = celebs[celebrityIndex] ?? celebs[0];
         const isActive =
           selectedIndex === index || hoveredIndex === index;
         return (

--- a/src/pages/all-types-view/index.page.tsx
+++ b/src/pages/all-types-view/index.page.tsx
@@ -52,6 +52,15 @@ const AllTypesView = () => {
         hoveredIndex={hoveredIndex}
         onSelect={handleSelect}
         onHover={setHoveredIndex}
+        celebrityIndex={0}
+      />
+
+      <CompassChart
+        selectedIndex={selectedIndex}
+        hoveredIndex={hoveredIndex}
+        onSelect={handleSelect}
+        onHover={setHoveredIndex}
+        celebrityIndex={2}
       />
 
       {colorType ? (
@@ -61,23 +70,6 @@ const AllTypesView = () => {
           </S.ColorTypeTitle>
 
           <Tag colorType={colorType} tags={resultColorData[colorType].tags} />
-
-          <S.CelebritiesRow>
-            {resultColorData[colorType].celebrities.map((celeb, idx) => (
-              <S.CelebrityItem key={celeb.name + idx}>
-                <S.CelebrityImage
-                  src={celeb.imageURL}
-                  alt={t(`${colorType}.celebrities.${idx}`)}
-                  width={76}
-                  height={76}
-                  $borderColor={color[selectedIndex].textColor}
-                />
-                <S.CelebrityName>
-                  {t(`${colorType}.celebrities.${idx}`)}
-                </S.CelebrityName>
-              </S.CelebrityItem>
-            ))}
-          </S.CelebritiesRow>
 
           <S.PaletteGrid>
             {resultColorData[colorType].gridColors.map(

--- a/src/pages/all-types-view/style.ts
+++ b/src/pages/all-types-view/style.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import Image from 'next/image';
 import { flexCustom, layout } from '@Styles/theme';
 
 type PaletteGridItemProps = {
@@ -60,33 +59,6 @@ export const Tag = styled.span<TagStyleProps>`
   color: ${({ theme, textColor }) =>
     ({ light: theme.white, dark: theme.gray[900] }[textColor])};
   font-size: 14px;
-`;
-
-export const CelebritiesRow = styled.div`
-  ${flexCustom('row', 'center', 'space-around')}
-  width: 100%;
-  padding: 0.25rem 0;
-`;
-
-export const CelebrityItem = styled.div`
-  ${flexCustom('column', 'center', 'center')}
-  row-gap: 0.5rem;
-`;
-
-export const CelebrityImage = styled(Image)<{ $borderColor: string }>`
-  width: 76px;
-  height: 76px;
-  border: 1.5px solid ${({ $borderColor }) => $borderColor};
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: ${({ theme }) => theme.white};
-`;
-
-export const CelebrityName = styled.span`
-  color: ${({ theme }) => theme.gray[700]};
-  font-size: ${({ theme }) => theme.font.size.sm};
-  font-weight: 500;
-  text-align: center;
 `;
 
 export const PaletteGrid = styled.div`


### PR DESCRIPTION
## Summary
- 여자 연예인 compass chart 아래에 **남자 연예인 compass chart** 를 추가 (각 타입의 `celebrities[2]` 사용)
- 두 차트가 `selectedIndex` / `hoveredIndex` 를 공유하여 한쪽에서 hover/click 하면 반대쪽 차트에서도 함께 하이라이트
- 클릭 시 나오던 3명 celebrity row 는 남자 chart 로 대체되며 제거
- 타입 선택/hover 시 중앙 축 라벨(Bright / Warm / Light / Cool / Mute / Deep) 이 해당 타입 컬러로 강조 (font-size 10→11, weight 500→700, 160ms 트랜지션)
- Warm/Cool 라벨이 두 개씩 있는데 계절에 맞는 축만 강조되도록 `warm-spring` / `warm-autumn` / `cool-summer` / `cool-winter` 로 구분

## Test plan
- [ ] `/all-types-view` 진입 시 여자 / 남자 compass chart 두 개가 세로로 표시됨
- [ ] 한쪽 차트의 avatar 를 클릭하면 양쪽 차트에서 동일 타입이 하이라이트됨
- [ ] hover / click 시 중앙의 해당 tone 라벨이 커지고 색상이 변함
- [ ] 봄 웜 선택 → `Warm` (spring 쪽) 만 강조 (autumn 의 Warm 은 강조되지 않음), 여름 쿨 / 겨울 쿨 도 동일
- [ ] 다시 클릭해 선택 해제하면 라벨이 원상복구되고 `clickType` 안내 문구가 나옴

🤖 Generated with [Claude Code](https://claude.com/claude-code)