### PR TITLE
release: all-types-view 남자 연예인 compass chart 추가

### DIFF
--- a/src/pages/all-types-view/CompassChart/constants.ts
+++ b/src/pages/all-types-view/CompassChart/constants.ts
@@ -58,3 +58,21 @@ export const SEASON_LABELS = [
   { key: 'autumn', label: '가을 AUTUMN', angle: 225, anchorIndex: 7 },
   { key: 'winter', label: '겨울 WINTER', angle: 315, anchorIndex: 10 },
 ] as const;
+
+// Maps each of the 12 color types (by their index in color[]) to the axis
+// label that best characterizes it. The two "Warm" axes (spring vs autumn)
+// and two "Cool" axes (summer vs winter) are disambiguated by suffix.
+export const TYPE_INDEX_TO_AXIS_KEY = [
+  'bright', // 0  springbright
+  'warm-spring', // 1  springwarm
+  'light', // 2  springlight
+  'light', // 3  summerlight
+  'cool-summer', // 4  summercool
+  'mute', // 5  summermute
+  'mute', // 6  autumnmute
+  'warm-autumn', // 7  autumnwarm
+  'deep', // 8  autumndeep
+  'deep', // 9  winterdeep
+  'cool-winter', // 10 wintercool
+  'bright', // 11 winterbright
+] as const;

--- a/src/pages/all-types-view/CompassChart/index.tsx
+++ b/src/pages/all-types-view/CompassChart/index.tsx
@@ -12,6 +12,7 @@ import {
   CHART_SIZE,
   OUTER_RADIUS,
   SEASON_LABELS,
+  TYPE_INDEX_TO_AXIS_KEY,
   getAvatarAngleDeg,
   polarToCartesian,
 } from './constants';
@@ -22,6 +23,7 @@ type Props = {
   hoveredIndex: number | undefined;
   onSelect: (index: number) => void;
   onHover: (index: number | undefined) => void;
+  celebrityIndex?: number;
 };
 
 const SEASON_LABEL_OFFSET = OUTER_RADIUS + 22;
@@ -33,8 +35,20 @@ function quadrantPath(startAngleDeg: number): string {
   return `M ${CENTER} ${CENTER} L ${start.x} ${start.y} A ${OUTER_RADIUS} ${OUTER_RADIUS} 0 0 1 ${end.x} ${end.y} Z`;
 }
 
-function CompassChart({ selectedIndex, hoveredIndex, onSelect, onHover }: Props) {
+function CompassChart({
+  selectedIndex,
+  hoveredIndex,
+  onSelect,
+  onHover,
+  celebrityIndex = 0,
+}: Props) {
   const { t } = useTranslation('common');
+
+  const activeIndex = hoveredIndex ?? selectedIndex;
+  const highlightedAxisKey =
+    activeIndex !== undefined ? TYPE_INDEX_TO_AXIS_KEY[activeIndex] : undefined;
+  const highlightColor =
+    activeIndex !== undefined ? color[activeIndex].textColor : undefined;
 
   return (
     <S.Wrapper>
@@ -122,19 +136,21 @@ function CompassChart({ selectedIndex, hoveredIndex, onSelect, onHover }: Props)
 
         <circle cx={CENTER} cy={CENTER} r="5" fill="#8a6d3b" />
 
-        {/* 6 axis labels inside the center circle */}
+        {/* 8 axis labels inside the center circle */}
         {AXIS_LABELS.map(({ key, label, angle }) => {
           const { x, y } = polarToCartesian(angle, AXIS_LABEL_RADIUS);
+          const isHighlighted = key === highlightedAxisKey;
           return (
             <text
               key={key}
               x={x}
               y={y + 3}
               textAnchor="middle"
-              fontSize="10"
+              fontSize={isHighlighted ? 11 : 10}
               fontFamily="'Noto Sans KR', sans-serif"
-              fontWeight="500"
-              fill="#7a5c2a"
+              fontWeight={isHighlighted ? 700 : 500}
+              fill={isHighlighted && highlightColor ? highlightColor : '#7a5c2a'}
+              style={{ transition: 'font-size 160ms ease, fill 160ms ease' }}
             >
               {label}
             </text>
@@ -163,7 +179,8 @@ function CompassChart({ selectedIndex, hoveredIndex, onSelect, onHover }: Props)
           getAvatarAngleDeg(index),
           AVATAR_RING_RADIUS
         );
-        const representative = resultColorData[type].celebrities[0];
+        const celebs = resultColorData[type].celebrities;
+        const representative = celebs[celebrityIndex] ?? celebs[0];
         const isActive =
           selectedIndex === index || hoveredIndex === index;
         return (

--- a/src/pages/all-types-view/index.page.tsx
+++ b/src/pages/all-types-view/index.page.tsx
@@ -52,6 +52,15 @@ const AllTypesView = () => {
         hoveredIndex={hoveredIndex}
         onSelect={handleSelect}
         onHover={setHoveredIndex}
+        celebrityIndex={0}
+      />
+
+      <CompassChart
+        selectedIndex={selectedIndex}
+        hoveredIndex={hoveredIndex}
+        onSelect={handleSelect}
+        onHover={setHoveredIndex}
+        celebrityIndex={2}
       />
 
       {colorType ? (
@@ -61,23 +70,6 @@ const AllTypesView = () => {
           </S.ColorTypeTitle>
 
           <Tag colorType={colorType} tags={resultColorData[colorType].tags} />
-
-          <S.CelebritiesRow>
-            {resultColorData[colorType].celebrities.map((celeb, idx) => (
-              <S.CelebrityItem key={celeb.name + idx}>
-                <S.CelebrityImage
-                  src={celeb.imageURL}
-                  alt={t(`${colorType}.celebrities.${idx}`)}
-                  width={76}
-                  height={76}
-                  $borderColor={color[selectedIndex].textColor}
-                />
-                <S.CelebrityName>
-                  {t(`${colorType}.celebrities.${idx}`)}
-                </S.CelebrityName>
-              </S.CelebrityItem>
-            ))}
-          </S.CelebritiesRow>
 
           <S.PaletteGrid>
             {resultColorData[colorType].gridColors.map(

--- a/src/pages/all-types-view/style.ts
+++ b/src/pages/all-types-view/style.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import Image from 'next/image';
 import { flexCustom, layout } from '@Styles/theme';
 
 type PaletteGridItemProps = {
@@ -60,33 +59,6 @@ export const Tag = styled.span<TagStyleProps>`
   color: ${({ theme, textColor }) =>
     ({ light: theme.white, dark: theme.gray[900] }[textColor])};
   font-size: 14px;
-`;
-
-export const CelebritiesRow = styled.div`
-  ${flexCustom('row', 'center', 'space-around')}
-  width: 100%;
-  padding: 0.25rem 0;
-`;
-
-export const CelebrityItem = styled.div`
-  ${flexCustom('column', 'center', 'center')}
-  row-gap: 0.5rem;
-`;
-
-export const CelebrityImage = styled(Image)<{ $borderColor: string }>`
-  width: 76px;
-  height: 76px;
-  border: 1.5px solid ${({ $borderColor }) => $borderColor};
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: ${({ theme }) => theme.white};
-`;
-
-export const CelebrityName = styled.span`
-  color: ${({ theme }) => theme.gray[700]};
-  font-size: ${({ theme }) => theme.font.size.sm};
-  font-weight: 500;
-  text-align: center;
 `;
 
 export const PaletteGrid = styled.div`


### PR DESCRIPTION
## Summary
develop → production 배포용 PR.

포함 변경사항:
- #314 feat(all-types-view): 남자 연예인 compass chart 추가 + axis 하이라이트

## Test plan
- [ ] production 배포 후 `/all-types-view` 진입 확인
- [ ] 여자 / 남자 두 compass chart 정상 렌더
- [ ] 한쪽 클릭 시 양쪽 하이라이트 동기화
- [ ] 중앙 축 라벨(tone) 강조 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)